### PR TITLE
44 sampler concat issue with empty dataframe

### DIFF
--- a/map2loop/config.py
+++ b/map2loop/config.py
@@ -117,7 +117,7 @@ class Config:
             "otype": (self.structure_config, "orientation_type"),
             "dd": (self.structure_config, "dipdir_column"),
             "d": (self.structure_config, "dip_column"),
-            "sf": (self.structure_config, "desciption_column"),
+            "sf": (self.structure_config, "description_column"),
             "bedding": (self.structure_config, "bedding_text"),
             "bo": (self.structure_config, "overturned_column"),
             "btype": (self.structure_config, "overturned_text"),

--- a/map2loop/sampler.py
+++ b/map2loop/sampler.py
@@ -149,6 +149,9 @@ class SamplerSpacing(Sampler):
                     df2["ID"] = row["ID"]
                 else:
                     df2["ID"] = 0
-                df = pandas.concat([df, df2])
+                if len(df) == 0:
+                    df = df2
+                else:
+                    df = pandas.concat([df, df2])
         df.reset_index(drop=True, inplace=True)
         return df


### PR DESCRIPTION
Quick check for size before concat, fixes the warning of concat to empty dataframe.

Added a typo for config (cause I was being lazy and didn't want to create a new issue).