### PR TITLE
New ThicknessCalculatorBeta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ docs/source/_auto_examples
 examples/*_tmp
 *.loop3d
 m2l_data_tmp/*
+packages.txt

--- a/map2loop/__init__.py
+++ b/map2loop/__init__.py
@@ -1,4 +1,5 @@
 from .project import Project
+from .interpolator import Interpolator, IDWInterpolator
 
 __all__ = ["Project"]
 from .version import __version__

--- a/map2loop/__init__.py
+++ b/map2loop/__init__.py
@@ -1,5 +1,5 @@
 from .project import Project
-from .interpolator import Interpolator, IDWInterpolator
+from .interpolator import NormalVectorInterpolator, DipDipDirectionInterpolator
 
 __all__ = ["Project"]
 from .version import __version__

--- a/map2loop/interpolator.py
+++ b/map2loop/interpolator.py
@@ -3,6 +3,7 @@ from typing import Tuple, Any
 
 import beartype
 import pandas
+import geopandas
 import numpy
 import math
 from scipy.interpolate import Rbf
@@ -37,7 +38,7 @@ class Interpolator(ABC):
 
     @beartype.beartype
     @abstractmethod
-    def setup_interpolation(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> pandas.DataFrame:
+    def setup_interpolation(self, map_data: MapData) -> Tuple[pandas.DataFrame, list, numpy.ndarray]:
         """
         abstract method to setup interpolation (abstract method)
 
@@ -61,7 +62,7 @@ class Interpolator(ABC):
 
     @beartype.beartype
     @abstractmethod
-    def interpolator(self,x: float, y: float, ni: float, xi: float, yi: float)-> Tuple[numpy.ndarray, list]:
+    def interpolator(self, x: float, y: float, ni: float, xi: float, yi: float) -> Tuple[numpy.ndarray, list]:
         """
         Interpolator method
 
@@ -80,7 +81,7 @@ class Interpolator(ABC):
 
     @beartype.beartype
     @abstractmethod
-    def interpolate(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> list:
+    def interpolate(self, map_data: MapData) -> list:
         """
         Execute interpolate method (abstract method)
 
@@ -96,9 +97,9 @@ class Interpolator(ABC):
         pass
 
 
-class IDWInterpolator(Interpolator):
+class NormalVectorInterpolator(Interpolator):
     """
-    Inverse Distance Weighting interpolation class
+    Normal vector interpolation class
 
     Args:
         Interpolator(ABC): Derived from Abstract Base Class
@@ -121,7 +122,7 @@ class IDWInterpolator(Interpolator):
 
     @beartype.beartype
     @abstractmethod
-    def setup_interpolation(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> pandas.DataFrame:
+    def setup_interpolation(self, map_data: MapData) -> pandas.DataFrame:
         """
         Setup the interpolation method (abstract method)
 
@@ -131,7 +132,7 @@ class IDWInterpolator(Interpolator):
             map_data (map2loop.MapData): a catchall so that access to all map data is available
         """
         # the following code is from LoopStructural
-        contact_orientations = contact_orientations.copy()
+        contact_orientations = map_data.raw_data[1].copy()
         if (
                 "nx" not in contact_orientations.columns
                 or "ny" not in contact_orientations.columns
@@ -182,15 +183,32 @@ class IDWInterpolator(Interpolator):
                 ):
                     contact_orientations["X"] = contact_orientations["easting"]
                 if (
+                        "X" not in contact_orientations.columns
+                        and "easting" not in contact_orientations.columns
+                ):
+                    contact_orientations["X"] = contact_orientations['geometry'].apply(lambda geom: geom.x)
+
+                if (
                         "Y" not in contact_orientations.columns
                         and "northing" in contact_orientations.columns
                 ):
                     contact_orientations["Y"] = contact_orientations["northing"]
                 if (
+                        "Y" not in contact_orientations.columns
+                        and "northing" not in contact_orientations.columns
+                ):
+                    contact_orientations["Y"] = contact_orientations['geometry'].apply(lambda geom: geom.y)
+                if (
                         "Z" not in contact_orientations.columns
                         and "altitude" in contact_orientations.columns
                 ):
                     contact_orientations["Z"] = contact_orientations["altitude"]
+                if (
+                        "Z" not in contact_orientations.columns
+                        and "altitude" not in contact_orientations.columns
+                ):
+                    contact_orientations["Z"] = 0
+
                 if (
                         "X" not in contact_orientations.columns
                         or "Y" not in contact_orientations.columns
@@ -247,7 +265,7 @@ class IDWInterpolator(Interpolator):
         return rbf(xi, yi)
 
     @beartype.beartype
-    def interpolate(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> numpy.ndarray:
+    def interpolate(self, map_data: MapData) -> numpy.ndarray:
         """
         Execute interpolation method (abstract method)
 
@@ -261,7 +279,7 @@ class IDWInterpolator(Interpolator):
 
         """
 
-        stratigraphic_orientations = self.setup_interpolation(contact_orientations, map_data)
+        stratigraphic_orientations = self.setup_interpolation(map_data)
         x, y = stratigraphic_orientations[["X", "Y"]].to_numpy()
         nx, ny, nz = stratigraphic_orientations[["nx", "ny", "nz"]].to_numpy()
         xi, yi = self.setup_grid(map_data)
@@ -271,4 +289,111 @@ class IDWInterpolator(Interpolator):
         ny_interp = self.interpolator(x, y, ny, xi, yi)
         nz_interp = self.interpolator(x, y, nz, xi, yi)
 
-        return numpy.array([nx_interp, ny_interp, nz_interp]).T
+        vecs = numpy.array([nx_interp, ny_interp, nz_interp]).T
+        vecs /= numpy.linalg.norm(vecs, axis=1)[:, None]
+
+        return vecs
+
+
+class DipInterpolator(Interpolator):
+    """
+
+
+    Args:
+        Interpolator(ABC): Derived from Abstract Base Class
+    """
+
+    def __init__(self):
+        """
+        Initialiser of for IDWInterpolator
+        """
+        self.interpolator_label = "IDWInterpolator"
+
+    def type(self):
+        """
+        Getter for subclass type label
+
+        Returns:
+            str: Name of subclass
+        """
+        return self.interpolator_label
+
+    @beartype.beartype
+    @abstractmethod
+    def setup_interpolation(self, map_data: MapData) -> Tuple[pandas.DataFrame, list, numpy.ndarray]:
+        """
+        Setup the interpolation method
+        """
+        contact_orientations = map_data.raw_data[1].copy()
+        contact_orientations['x'] = contact_orientations['geometry'].apply(lambda geom: geom.x)
+        contact_orientations['y'] = contact_orientations['geometry'].apply(lambda geom: geom.y)
+        x, y = contact_orientations[['x', 'y']].to_list()
+        dip = contact_orientations["dip"].to_list()
+
+        return x, y, dip
+
+    @beartype.beartype
+    def setup_grid(self, map_data: MapData) -> tuple[tuple[Any, Any] | Any, tuple[Any, Any] | Any]:
+        """
+        Setup the grid for interpolation
+
+        Args:
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+        """
+        # Define the desired cell size
+        cell_size = 0.05 * (map_data.bounding_box["maxx"] - map_data.bounding_box["minx"])
+
+        # Calculate the grid resolution
+        grid_resolution = round((map_data.bounding_box["maxx"] - map_data.bounding_box["minx"]) / cell_size)
+
+        # Generate the grid
+        xi = numpy.linspace(
+            map_data.bounding_box["minx"], map_data.bounding_box["maxx"], grid_resolution
+        )
+        yi = numpy.linspace(
+            map_data.bounding_box["miny"], map_data.bounding_box["maxy"], grid_resolution
+        )
+        return xi, yi
+
+    @beartype.beartype
+    def interpolator(self, x: Any, y: Any, ni: Any, xi: Any, yi: Any) -> numpy.ndarray:
+        """
+        Inverse Distance Weighting interpolation method
+
+        Args:
+            x (Any): x-coordinate of the point
+            y (Any): y-coordinate of the point
+            ni (Any): list or numpy.ndarray of values to interpolate
+            xi (Any): x-coordinate of the point where interpolation of ni is performed (grid point)
+            yi (Any): y-coordinate of the point where interpolation of ni is performed (grid point)
+
+        Returns:
+            Rbf: radial basis function object
+        """
+
+        rbf = Rbf(x, y, ni, function="linear")
+
+        return rbf(xi, yi)
+
+    @beartype.beartype
+    def interpolate(self, map_data: MapData) -> numpy.ndarray:
+        """
+        Execute interpolation method (abstract method)
+
+        Args:
+            contact_orientations (pandas.DataFrame): structural data with columns: 'X', 'Y', 'Z', 'dipDir/dipdir',
+            'dip', 'layer', 'name'
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+
+        Returns:
+            list: sorted list of unit names
+
+        """
+
+        x, y, dip = self.setup_interpolation(map_data)
+        xi, yi = self.setup_grid(map_data)
+
+        # interpolate each component of the normal vector nx, ny, nz
+        interpolated_dip = self.interpolator(x, y, dip, xi, yi)
+
+        return interpolated_dip

--- a/map2loop/interpolator.py
+++ b/map2loop/interpolator.py
@@ -1,0 +1,274 @@
+from abc import ABC, abstractmethod
+from typing import Tuple, Any
+
+import beartype
+import pandas
+import numpy
+import math
+from scipy.interpolate import Rbf
+from pandas import DataFrame
+
+from .mapdata import MapData
+from utils import strike_dip_vector
+
+
+class Interpolator(ABC):
+    """
+    Base Class of Interpolator used to force structure of Interpolator
+
+    Args:
+        ABC (ABC): Derived from Abstract Base Class
+    """
+
+    def __init__(self):
+        """
+        Initialiser of for Interpolator
+        """
+        self.interpolator_label = "InterpolatorBaseClass"
+
+    def type(self):
+        """
+        Getter for subclass type label
+
+        Returns:
+            str: Name of subclass
+        """
+        return self.interpolator_label
+
+    @beartype.beartype
+    @abstractmethod
+    def setup_interpolation(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> pandas.DataFrame:
+        """
+        abstract method to setup interpolation (abstract method)
+
+        Args:
+            contact_orientations (pandas.DataFrame): structural data with columns: 'X', 'Y', 'Z', 'dipDir/dipdir',
+            'dip', 'layer', 'name'
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+        """
+        pass
+
+    @beartype.beartype
+    @abstractmethod
+    def setup_grid(self, map_data: MapData) -> Tuple[numpy.ndarray, list]:
+        """
+        abstract method to setup an XY grid (abstract method)
+
+        Args:
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+        """
+        pass
+
+    @beartype.beartype
+    @abstractmethod
+    def interpolator(self,x: float, y: float, ni: float, xi: float, yi: float)-> Tuple[numpy.ndarray, list]:
+        """
+        Interpolator method
+
+        Args:
+            x (float): x-coordinate of the point
+            y (float): y-coordinate of the point
+            ni (int): number of points
+            xi (float): x-coordinate of the point
+            yi (float): z-coordinate of the point
+
+        Returns:
+            float: interpolated value
+        """
+
+        pass
+
+    @beartype.beartype
+    @abstractmethod
+    def interpolate(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> list:
+        """
+        Execute interpolate method (abstract method)
+
+        Args:
+            contact_orientations (pandas.DataFrame): structural data with columns: 'X', 'Y', 'Z', 'dipDir/dipdir',
+            'dip', 'layer', 'name'
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+
+        Returns:
+            list: sorted list of unit names
+
+        """
+        pass
+
+
+class IDWInterpolator(Interpolator):
+    """
+    Inverse Distance Weighting interpolation class
+
+    Args:
+        Interpolator(ABC): Derived from Abstract Base Class
+    """
+
+    def __init__(self):
+        """
+        Initialiser of for IDWInterpolator
+        """
+        self.interpolator_label = "IDWInterpolator"
+
+    def type(self):
+        """
+        Getter for subclass type label
+
+        Returns:
+            str: Name of subclass
+        """
+        return self.interpolator_label
+
+    @beartype.beartype
+    @abstractmethod
+    def setup_interpolation(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> pandas.DataFrame:
+        """
+        Setup the interpolation method (abstract method)
+
+        Args:
+            contact_orientations (pandas.DataFrame): structural data with columns: 'X', 'Y', 'Z', 'dipDir/dipdir',
+            'dip', 'layer', 'name'
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+        """
+        # the following code is from LoopStructural
+        contact_orientations = contact_orientations.copy()
+        if (
+                "nx" not in contact_orientations.columns
+                or "ny" not in contact_orientations.columns
+                or "nz" not in contact_orientations.columns
+        ):
+            if (
+                    "strike" not in contact_orientations.columns
+                    and "azimuth" in contact_orientations.columns
+            ):
+                contact_orientations["strike"] = contact_orientations["azimuth"] - 90
+            if (
+                    "strike" not in contact_orientations.columns
+                    and "dipdir" in contact_orientations.columns
+            ):
+                contact_orientations["strike"] = contact_orientations["dipdir"] - 90
+            if (
+                    "strike" not in contact_orientations.columns
+                    and "dipDir" in contact_orientations.columns
+            ):
+                contact_orientations["strike"] = contact_orientations["dipDir"] - 90
+            if (
+                    "strike" in contact_orientations.columns
+                    and "dip" in contact_orientations.columns
+            ):
+                contact_orientations["nx"] = numpy.nan
+                contact_orientations["ny"] = numpy.nan
+                contact_orientations["nz"] = numpy.nan
+                contact_orientations[["nx", "ny", "nz"]] = strike_dip_vector(
+                    contact_orientations["strike"], contact_orientations["dip"]
+                )
+            if (
+                    "nx" not in contact_orientations.columns
+                    or "ny" not in contact_orientations.columns
+                    or "nz" not in contact_orientations.columns
+            ):
+                raise ValueError(
+                    "Contact orientation data must contain either strike/dipdir, dip, or nx, ny, nz"
+                )
+
+            if (
+                    "X" not in contact_orientations.columns
+                    or "Y" not in contact_orientations.columns
+                    or "Z" not in contact_orientations.columns
+            ):
+                if (
+                        "X" not in contact_orientations.columns
+                        and "easting" in contact_orientations.columns
+                ):
+                    contact_orientations["X"] = contact_orientations["easting"]
+                if (
+                        "Y" not in contact_orientations.columns
+                        and "northing" in contact_orientations.columns
+                ):
+                    contact_orientations["Y"] = contact_orientations["northing"]
+                if (
+                        "Z" not in contact_orientations.columns
+                        and "altitude" in contact_orientations.columns
+                ):
+                    contact_orientations["Z"] = contact_orientations["altitude"]
+                if (
+                        "X" not in contact_orientations.columns
+                        or "Y" not in contact_orientations.columns
+                        or "Z" not in contact_orientations.columns
+                ):
+                    raise ValueError(
+                        "Contact orientation data must contain either X, Y, Z or easting, northing, altitude"
+                    )
+
+        return contact_orientations
+
+    @beartype.beartype
+    def setup_grid(self, map_data: MapData) -> numpy.ndarray:
+        """
+        Setup the grid for interpolation
+
+        Args:
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+        """
+        # Define the desired cell size
+        cell_size = 0.05 * (map_data.bounding_box["maxx"] - map_data.bounding_box["minx"])
+
+        # Calculate the grid resolution
+        grid_resolution = round((map_data.bounding_box["maxx"] - map_data.bounding_box["minx"]) / cell_size)
+
+        # Generate the grid
+        xi = numpy.linspace(
+            map_data.bounding_box["minx"], map_data.bounding_box["maxx"], grid_resolution
+        )
+        yi = numpy.linspace(
+            map_data.bounding_box["miny"], map_data.bounding_box["maxy"], grid_resolution
+        )
+        return xi, yi
+
+    @beartype.beartype
+    def interpolator(self, x: float, y: float, ni: float, xi: float, yi: float) -> numpy.ndarray:
+
+        """
+        Inverse Distance Weighting interpolation method
+
+        Args:
+            x (float): x-coordinate of the point
+            y (float): y-coordinate of the point
+            ni (int): value to interpolate
+            xi (float): x-coordinate of the point where interpolation of ni is performed (grid point)
+            yi (float): y-coordinate of the point where interpolation of ni is performed (grid point)
+
+        Returns:
+            Rbf: radial basis function object
+        """
+
+        rbf = Rbf(x, y, ni, function="linear")
+
+        return rbf(xi, yi)
+
+    @beartype.beartype
+    def interpolate(self, contact_orientations: pandas.DataFrame, map_data: MapData) -> numpy.ndarray:
+        """
+        Execute interpolation method (abstract method)
+
+        Args:
+            contact_orientations (pandas.DataFrame): structural data with columns: 'X', 'Y', 'Z', 'dipDir/dipdir',
+            'dip', 'layer', 'name'
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+
+        Returns:
+            list: sorted list of unit names
+
+        """
+
+        stratigraphic_orientations = self.setup_interpolation(contact_orientations, map_data)
+        x, y = stratigraphic_orientations[["X", "Y"]].to_numpy()
+        nx, ny, nz = stratigraphic_orientations[["nx", "ny", "nz"]].to_numpy()
+        xi, yi = self.setup_grid(map_data)
+
+        # interpolate each component of the normal vector nx, ny, nz
+        nx_interp = self.interpolator(x, y, nx, xi, yi)
+        ny_interp = self.interpolator(x, y, ny, xi, yi)
+        nz_interp = self.interpolator(x, y, nz, xi, yi)
+
+        return numpy.array([nx_interp, ny_interp, nz_interp]).T

--- a/map2loop/interpolator.py
+++ b/map2loop/interpolator.py
@@ -249,7 +249,7 @@ class NormalVectorInterpolator(Interpolator):
 
         Args:
             map_data (map2loop.MapData): a catchall so that access to all map data is available
-        """
+hw        """
         # Define the desired cell size
         cell_size = 0.01 * (map_data.bounding_box["maxx"] - map_data.bounding_box["minx"])
 

--- a/map2loop/m2l_enums.py
+++ b/map2loop/m2l_enums.py
@@ -1,13 +1,6 @@
 from enum import IntEnum
 
 
-class Sampletype(IntEnum):
-    GEOLOGY = 0
-    STRUCTURE = 1
-    FAULT = 2
-    FOLD = 3
-    DTM = 4
-
 class Datatype(IntEnum):
     GEOLOGY = 0
     STRUCTURE = 1

--- a/map2loop/m2l_enums.py
+++ b/map2loop/m2l_enums.py
@@ -1,6 +1,13 @@
 from enum import IntEnum
 
 
+class Sampletype(IntEnum):
+    GEOLOGY = 0
+    STRUCTURE = 1
+    FAULT = 2
+    FOLD = 3
+    DTM = 4
+
 class Datatype(IntEnum):
     GEOLOGY = 0
     STRUCTURE = 1

--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -73,6 +73,7 @@ class MapData:
         self.data = [None] * len(Datatype)
         self.contacts = None
         self.basal_contacts = None
+        self.sampled_contacts = None
         self.filenames = [None] * len(Datatype)
         # self.output_filenames = [None] * len(Datatype)
         self.dirtyflags = [True] * len(Datatype)

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -335,8 +335,8 @@ class Project(object):
         """
         # Use stratigraphic column to determine basal contacts
         self.map_data.extract_basal_contacts(self.stratigraphic_column.column)
-        self.sampled_contacts = self.samplers[Datatype.GEOLOGY].sample(self.map_data.basal_contacts)
-        self.map_data.get_value_from_raster_df(Datatype.DTM, self.sampled_contacts)
+        self.map_data.sampled_contacts = self.samplers[Datatype.GEOLOGY].sample(self.map_data.basal_contacts)
+        self.map_data.get_value_from_raster_df(Datatype.DTM, self.map_data.sampled_contacts)
 
     def calculate_stratigraphic_order(self, take_best=False):
         """
@@ -508,11 +508,11 @@ class Project(object):
         LPF.Set(self.loop_filename, "stratigraphicLog", data=stratigraphic_data, verbose=True)
 
         # Save contacts
-        contacts_data = numpy.zeros(len(self.sampled_contacts), LPF.contactObservationType)
-        contacts_data["layerId"] = self.sampled_contacts["ID"]
-        contacts_data["easting"] = self.sampled_contacts["X"]
-        contacts_data["northing"] = self.sampled_contacts["Y"]
-        contacts_data["altitude"] = self.sampled_contacts["Z"]
+        contacts_data = numpy.zeros(len(self.map_data.sampled_contacts), LPF.contactObservationType)
+        contacts_data["layerId"] = self.map_data.sampled_contacts["ID"]
+        contacts_data["easting"] = self.map_data.sampled_contacts["X"]
+        contacts_data["northing"] = self.map_data.sampled_contacts["Y"]
+        contacts_data["altitude"] = self.map_data.sampled_contacts["Z"]
         LPF.Set(self.loop_filename, "contacts", data=contacts_data, verbose=True)
 
         # Save fault information
@@ -605,7 +605,7 @@ class Project(object):
                 self.map_data.basal_contacts[self.map_data.basal_contacts["type"] == "BASAL"].plot(ax=base)
                 return
             elif overlay == "contacts":
-                points = self.sampled_contacts
+                points = self.map_data.sampled_contacts
             elif overlay == "orientations":
                 points = self.structure_samples
             elif overlay == "faults":

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -1,18 +1,17 @@
-import os
 from abc import ABC, abstractmethod
 import beartype
 import numpy
+from scipy.spatial.distance import euclidean
 import pandas
 import geopandas
 from statistics import mean
 from .mapdata import MapData
-from map2loop.sampler import SamplerSpacing
-from interpolator import NormalVectorInterpolator, DipInterpolator
-from utils import normal_vector_to_dipdirection_dip, create_points
+from scipy.interpolate import Rbf
+from .interpolator import DipDipDirectionInterpolator
+from .utils import create_points
 from .m2l_enums import Datatype
-from shapely.ops import nearest_points
-from shapely.geometry import Point, LineString
-from shapely import shortest_line, dwithin, length
+from shapely.geometry import Point, shape
+from shapely import dwithin, shortest_line
 
 
 class ThicknessCalculator(ABC):
@@ -41,11 +40,12 @@ class ThicknessCalculator(ABC):
     @beartype.beartype
     @abstractmethod
     def compute(
-            self,
-            units: pandas.DataFrame,
-            stratigraphic_order: list,
-            basal_contacts: geopandas.GeoDataFrame,
-            map_data: MapData,
+        self,
+        units: pandas.DataFrame,
+        stratigraphic_order: list,
+        basal_contacts: geopandas.GeoDataFrame,
+        structure_data: pandas.DataFrame,
+        map_data: MapData,
     ) -> pandas.DataFrame:
         """
         Execute thickness calculator method (abstract method)
@@ -54,6 +54,7 @@ class ThicknessCalculator(ABC):
             units (pandas.DataFrame): the data frame of units to add thicknesses to
             stratigraphic_order (list): a list of unit names sorted from youngest to oldest
             basal_contacts (geopandas.GeoDataFrame): basal contact geo data with locations and unit names of the contacts (columns must contain ["ID","basal_unit","type","geometry"])
+            structure_data (pandas.DataFrame): sampled structural data
             map_data (map2loop.MapData): a catchall so that access to all map data is available
 
         Returns:
@@ -75,11 +76,11 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
 
     @beartype.beartype
     def compute(
-            self,
-            units: pandas.DataFrame,
-            stratigraphic_order: list,
-            basal_contacts: pandas.DataFrame,
-            map_data: MapData,
+        self,
+        units: pandas.DataFrame,
+        stratigraphic_order: list,
+        basal_contacts: pandas.DataFrame,
+        map_data: MapData,
     ) -> pandas.DataFrame:
         """
         Execute thickness calculator method takes unit data, basal_contacts and stratigraphic order and attempts to estimate unit thickness.
@@ -110,15 +111,15 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
         for i in range(1, len(stratigraphic_order) - 1):
             # Compare basal contacts of adjacent units
             if (
-                    stratigraphic_order[i] in basal_unit_list
-                    and stratigraphic_order[i + 1] in basal_unit_list
+                stratigraphic_order[i] in basal_unit_list
+                and stratigraphic_order[i + 1] in basal_unit_list
             ):
                 contact1 = basal_contacts[
                     basal_contacts["basal_unit"] == stratigraphic_order[i]
-                    ]["geometry"].to_list()[0]
+                ]["geometry"].to_list()[0]
                 contact2 = basal_contacts[
                     basal_contacts["basal_unit"] == stratigraphic_order[i + 1]
-                    ]["geometry"].to_list()[0]
+                ]["geometry"].to_list()[0]
                 if contact1 is not None and contact2 is not None:
                     distance = contact1.distance(contact2)
                 else:
@@ -137,9 +138,8 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
             # Find row in unit_dataframe corresponding to unit and replace thickness value if it is -1 or larger than distance
             idx = thicknesses.index[
                 thicknesses["name"] == stratigraphic_order[i]
-                ].tolist()[0]
+            ].tolist()[0]
             if thicknesses.loc[idx, "thickness"] == -1:
-
                 val = distance
             else:
                 val = min(distance, thicknesses.at[idx, "thickness"])
@@ -163,7 +163,7 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
 class ThicknessCalculatorBeta(ThicknessCalculator):
     """
     This class is a subclass of the ThicknessCalculator abstract base class. It implements the thickness calculation
-    method for a given set of data points. The class is initialized without any arguments.
+    method for a given set of interpolated data points.
 
     Attributes:
         thickness_calculator_label (str): A string that stores the label of the thickness calculator.
@@ -171,99 +171,105 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
 
     Methods:
         compute(units: pandas.DataFrame, stratigraphic_order: list, basal_contacts: pandas.DataFrame, map_data: MapData)
-        -> pandas.DataFrame:
-        Calculates a thickness map for the overall map area.
+        -> pandas.DataFrame: Calculates a thickness map for the overall map area.
     """
+
     def __init__(self):
         """
         Initialiser for beta version of the thickness calculator
         """
         self.thickness_calculator_label = "ThicknessCalculatorBeta"
+        self.lines = []
 
-    def compute(self,
-                units: pandas.DataFrame,
-                stratigraphic_order: list,
-                basal_contacts: pandas.DataFrame,
-                map_data: MapData,
-                ) -> pandas.DataFrame:
 
-        # The rest of the code...
-    def __init__(self):
+    @beartype.beartype
+    def compute(
+        self,
+        units: pandas.DataFrame,
+        stratigraphic_order: list,
+        basal_contacts: pandas.DataFrame,
+        structure_data: pandas.DataFrame,
+        map_data: MapData,
+    ) -> pandas.DataFrame:
         """
-        Initialiser for theta version of the thickness calculator
-        """
-        self.thickness_calculator_label = "ThicknessCalculatorBeta"
-
-    def compute(self,
-                units: pandas.DataFrame,
-                stratigraphic_order: list,
-                basal_contacts: pandas.DataFrame,
-                map_data: MapData,
-                ) -> pandas.DataFrame:
-        """
-
         Execute thickness calculator method takes unit data, basal_contacts, stratigraphic order, orientation data and
-        DTM data to estimate a thickness map.
-        # TODO: need to find better approach to calculate thickness for top and bottom units
+        DTM data to estimate unit thickness.
+
+        The method works by iterating over the stratigraphic order of units. For each unit, it finds the basal contact
+        points and the top contact points. It then calculates the shortest line between these points. For each basal
+        contact point, it finds the interpolated points that are within 10% of the length of the shortest line. It then
+        calculates the true thickness of the unit at these points using the formula t = L . sin dip, where L is the
+        length of the line orthogonal to both contacts and dip is the dip of the interpolated points.
+        The method then calculates the median thickness and standard deviation for the unit.
 
         Args:
             units (pandas.DataFrame): the data frame of units to add thicknesses to
             stratigraphic_order (list): a list of unit names sorted from youngest to oldest
             basal_contacts (geopandas.GeoDataFrame): basal contact geo data with locations and unit names of the contacts (columns must contain ["ID","basal_unit","type","geometry"])
+            structure_data (pandas.DataFrame): sampled structural data
             map_data (map2loop.MapData): a catchall so that access to all map data is available
 
         Returns:
-            pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
+            pandas.DataFrame: units dataframe with added thickness column
         """
-        #TODO: find a way to provide either average thickness for each unit
-        no_distance = -1.0
-        basal_contacts = basal_contacts[basal_contacts["type"] == "BASAL"]
+        basal_contacts = basal_contacts[basal_contacts["type"] == "BASAL"].copy()
         thicknesses = units.copy()
         # Set default value
-        thicknesses["thickness"] = no_distance
+        thicknesses["betaThickness"] = -1.0
+        thicknesses["betaStdDev"] = 0
         basal_unit_list = basal_contacts["basal_unit"].to_list()
         # increase buffer around basal contacts to ensure that the points are included as intersections
-        basal_contacts['geometry'] = basal_contacts['geometry'].buffer(0.01)
-        # TODO: it's better to access the straphigraphyLocations directly from the map_data object
+        basal_contacts["geometry"] = basal_contacts["geometry"].buffer(0.01)
         # get the sampled contacts
         contacts = geopandas.GeoDataFrame(map_data.sampled_contacts)
         # build points from x and y coordinates
-        contacts['geometry'] = contacts.apply(lambda row: Point(row.X, row.Y), axis=1)
+        contacts["geometry"] = contacts.apply(lambda row: Point(row.X, row.Y), axis=1)
         # set the crs of the contacts to the crs of the units
-        contacts = contacts.set_crs(crs=units.crs)
+        contacts = contacts.set_crs(crs=basal_contacts.crs)
         # get the elevation Z of the contacts
         contacts = map_data.get_value_from_raster_df(Datatype.DTM, contacts)
         # update the geometry of the contact points to include the Z value
-        contacts['geometry'] = contacts.apply(lambda row: Point(row.geometry.x, row.geometry.y, row['Z']), axis=1)
+        contacts["geometry"] = contacts.apply(
+            lambda row: Point(row.geometry.x, row.geometry.y, row["Z"]), axis=1
+        )
         # spatial join the contact points with the basal contacts to get the unit for each contact point
-        contacts = contacts.sjoin(basal_contacts, how='inner', predicate='intersects')
-        # interpolate orientation data using bounding box
-        interpolator = NormalVectorInterpolator()
-        normal_vectors = interpolator.interpolate(map_data)
-        # convert interpolated normal vectors to dip and dip direction
-        dip, dip_direction = normal_vector_to_dipdirection_dip(normal_vectors[:, 0],
-                                                               normal_vectors[:, 1],
-                                                               normal_vectors[:, 2])
+        contacts = contacts.sjoin(basal_contacts, how="inner", predicate="intersects")
+        contacts = contacts[["X", "Y", "Z", "geometry", "basal_unit"]].copy()
+        bounding_box = map_data.get_bounding_box()
+        # Interpolate the dip of the contacts
+        interpolator = DipDipDirectionInterpolator(data_type="dip")
+        dip = interpolator.interpolate(bounding_box, structure_data, interpolator=Rbf)
         # create a GeoDataFrame of the interpolated orientations
         interpolated_orientations = geopandas.GeoDataFrame()
         # add the dip and dip direction to the GeoDataFrame
         interpolated_orientations["dip"] = dip
-        interpolated_orientations["dip_direction"] = dip_direction
+        # interpolated_orientations["dip_direction"] = dip_direction
         # get the x and y coordinates of the interpolated points
+        interpolated_orientations["X"] = interpolator.xi
+        interpolated_orientations["Y"] = interpolator.yi
         xy = numpy.array([interpolator.xi, interpolator.yi]).T
         # create Point objects from the x and y coordinates
         interpolated_orientations["geometry"] = create_points(xy)
         # set the crs of the interpolated orientations to the crs of the units
-        interpolated_orientations = interpolated_orientations.set_crs(crs=units.crs)
+        interpolated_orientations = interpolated_orientations.set_crs(
+            crs=basal_contacts.crs
+        )
         # get the elevation Z of the interpolated points
-        interpolated = map_data.get_value_from_raster_df(Datatype.DTM, interpolated_orientations)
+        interpolated = map_data.get_value_from_raster_df(
+            Datatype.DTM, interpolated_orientations
+        )
         # update the geometry of the interpolated points to include the Z value
-        interpolated['geometry'] = interpolated.apply(
-            lambda row: Point(row.geometry.x, row.geometry.y, row['Z']), axis=1)
+        interpolated["geometry"] = interpolated.apply(
+            lambda row: Point(row.geometry.x, row.geometry.y, row["Z"]), axis=1
+        )
         # for each interpolated point, assign name of unit using spatial join
-        interpolated_orientations = interpolated_orientations.sjoin(units, how="inner", op="within")
+        units = map_data.get_map_data(Datatype.GEOLOGY)
+        interpolated_orientations = interpolated_orientations.sjoin(
+            units, how="inner", predicate="within"
+        )
         interpolated_orientations = interpolated_orientations[
-            ["geometry", "dipdir", "dip", "ID_left", "UNITNAME"]].copy()
+            ["geometry", "dip", "UNITNAME"]
+        ].copy()
 
         if len(stratigraphic_order) < 3:
             print(
@@ -271,71 +277,67 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
             )
             return thicknesses
 
-        thickness_dataframes = []
-
-        for i in range(1, len(stratigraphic_order) - 1):
-            # Compare basal contacts of adjacent units
+        for i in range(0, len(stratigraphic_order) - 1):
             if (
-                    stratigraphic_order[i] in basal_unit_list
-                    and stratigraphic_order[i + 1] in basal_unit_list
+                stratigraphic_order[i] in basal_unit_list
+                and stratigraphic_order[i + 1] in basal_unit_list
             ):
-                basal_contact = contacts[
+                basal_contact = contacts.loc[
                     contacts["basal_unit"] == stratigraphic_order[i]
-                    ]["geometry"]
-                top_contact = contacts[
-                    contacts["basal_unit"] == stratigraphic_order[i + 1]
-                    ]["geometry"]
-
+                ].copy()
+                top_contact = basal_contacts.loc[
+                    basal_contacts["basal_unit"] == stratigraphic_order[i + 1]
+                ].copy()
+                top_contact_geometry = [
+                    shape(geom.__geo_interface__) for geom in top_contact.geometry
+                ]
                 if basal_contact is not None and top_contact is not None:
-                    # distance = contact1.distance(contact2)
                     interp_points = interpolated_orientations.loc[
-                        interpolated_orientations["UNITNAME"] == basal_contact["basal_unit"], "geometry"].copy()
-                    x = numpy.array([point.x for point in interp_points])
-                    y = numpy.array([point.y for point in interp_points])
-                    interp_orientations = interpolated_orientations.loc[
-                        interpolated_orientations["UNITNAME"] == basal_contact["basal_unit"], ["dip", "dipdir"]].copy()
-
+                        interpolated_orientations["UNITNAME"] == stratigraphic_order[i],
+                        "geometry",
+                    ].copy()
+                    dip = interpolated_orientations.loc[
+                        interpolated_orientations["UNITNAME"] == stratigraphic_order[i],
+                        "dip",
+                    ].to_numpy()
+                    _thickness = []
                     for j, row in basal_contact.iterrows():
-                        # Storage dataframe
-                        dataframe = pandas.DataFrame()
-                        # 6. find the shortest line between the basal contact points and top contact points
-                        short_line = shortest_line(row.geometry, top_contact)
-                        # calculate the length of the shortest line
-                        _length = length(short_line)
-                        # find the indices of the points that are within 5% of the length of the shortest line
-                        indices = numpy.array(dwithin(short_line, interp_points, _length * 0.05))
-                        # store the x and y coordinates of the points that are within
-                        # 5% of the length of the shortest line
-                        dataframe[i, 'X'] = x[indices]
-                        dataframe[i, 'Y'] = y[indices]
-                        # get the dip and dip direction of the points that are within
-                        # 5% of the length of the shortest line
-                        dip = numpy.deg2rad(interp_orientations['dip'].to_numpy()[indices])
-                        dipdir = numpy.deg2rad(interp_orientations['dipdir'].to_numpy()[indices])
-                        # get the end points of the shortest line
-                        end_point = short_line.coords[-1]
-                        end_x, end_y, end_z = end_point
-                        # calculate the angle ρ
-                        p = numpy.arccos(
-                            ((row.X - end_x) / _length) * numpy.sin(dipdir) * numpy.sin(dip) +
-                            ((row.Y - end_y) / _length) * numpy.cos(dipdir) * numpy.sin(dip) +
-                            ((row.Z - end_z) / _length) * numpy.cos(dip)
+                        # find the shortest line between the basal contact points and top contact points
+                        short_line = shortest_line(row.geometry, top_contact_geometry)
+                        self.lines.append(short_line)
+                        # extract the end points of the shortest line
+                        p1 = numpy.asarray(short_line[0].coords[0])
+                        p2 = numpy.asarray(short_line[0].coords[-1])
+                        # get the elevation Z of the end point p2
+                        p2[2] = map_data.get_value_from_raster(
+                            Datatype.DTM, p2[0], p2[1]
                         )
-                        # calculate the true thickness t = L . cos ρ
-                        thickness = numpy.abs(_length * numpy.cos(p))
-                        # store the thickness in the dataframe
-                        dataframe[i, 'thickness'] = thickness
-                        # store the dataframe in a thickness_dataframes list
-                        thickness_dataframes.append(dataframe)
-                else:
-                    print(
-                        f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
-                    )
-                    # distance = no_distance
+                        # calculate the length of the shortest line
+                        line_length = euclidean(p1, p2)
+                        # find the indices of the points that are within 5% of the length of the shortest line
+                        indices = dwithin(short_line, interp_points, line_length * 0.1)
+                        # get the dip of the points that are within
+                        # 10% of the length of the shortest line
+                        _dip = numpy.deg2rad(dip[indices])
+                        # get the end points of the shortest line
+                        # calculate the true thickness t = L . sin dip
+                        thickness = line_length * numpy.sin(_dip)
+                        # Average thickness along the shortest line
+                        _thickness.append(numpy.nanmean(thickness))
+
+                    # calculate the median thickness and standard deviation for the unit
+                    _thickness = numpy.asarray(_thickness, dtype=numpy.float64)
+                    median = numpy.nanmedian(_thickness)
+                    std_dev = numpy.nanstd(_thickness)
+
+                    idx = thicknesses.index[
+                        thicknesses["name"] == stratigraphic_order[i + 1]
+                    ].tolist()[0]
+                    thicknesses.loc[idx, "betaThickness"] = median
+                    thicknesses.loc[idx, "betaStdDev"] = std_dev
             else:
                 print(
                     f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                 )
 
-        thicknesses = pandas.concat(thickness_dataframes, axis=1)
         return thicknesses

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -6,6 +6,7 @@ import pandas
 import geopandas
 from statistics import mean
 from .mapdata import MapData
+from map2loop.sampler import SamplerSpacing
 
 
 class ThicknessCalculator(ABC):
@@ -195,13 +196,15 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
         Returns:
         None: The function writes the results to an output file and does not return anything.
         """
-        temporary_path = map_data.tmp_path
+        # TODO: find a way to use sampled contacts - stratigraphyLocations?
         # Load the contact points and interpolated data from the temporary path
-        contact_points_file = os.path.join(temporary_path, "raw_contacts.csv")
-        interpolated_combo_file = os.path.join(temporary_path, "combo_full.csv")
+        # contact_points_file = os.path.join(temporary_path, "raw_contacts.csv")
+        contact_points_file = map_data.contacts
+        # TODO: implement interpolation code
+        # interpolated_combo_file = os.path.join(temporary_path, "combo_full.csv")
 
         # Load the basal contacts as a geopandas dataframe
-        basal_contacts = geopandas.read_file(os.path.join(temporary_path, "/basal_contacts.shp.zip"))
+        # basal_contacts = geopandas.read_file(os.path.join(temporary_path, "/basal_contacts.shp.zip"))
 
         # Load the sorted data
         all_sorts = pandas.read_csv(os.path.join(temporary_path, "all_sorts.csv"))
@@ -364,437 +367,35 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
         )
 
 
-@beartype.beartype
-def calc_thickness_with_grid(config: Config, map_data: MapData):
-    contact_points_file = os.path.join(config.temporary_path, "raw_contacts.csv")
-    dtm = map_data.get_map_data(Datatype.DTM).open()
-    # load basal contacts as geopandas dataframe
-    contact_lines = gpd.read_file(
-        os.path.join(config.temporary_path, "basal_contacts.shp.zip")
-    )
-    all_sorts = pd.read_csv(os.path.join(config.temporary_path, "all_sorts.csv"))
-    all_sorts["index2"] = all_sorts.index
-    # all_sorts.set_index('code',inplace=True)
-    geol = map_data.get_map_data(Datatype.GEOLOGY).copy()
-    # geol=gpd.read_file(os.path.join(config.temporary_path, 'geol_clip.shp'))
-    geol.drop_duplicates(subset="UNIT_NAME", inplace=True)
-    # geol.set_index('UNIT_NAME',inplace=True)
-    drops = geol[
-        geol["DESCRIPTION"].str.contains(config.c_l["sill"])
-        & geol["ROCKTYPE1"].str.contains(config.c_l["intrusive"])
-        ]
-    for ind, drop in drops.iterrows():
-        all_sorts.drop(labels=drop.name, inplace=True, errors="ignore")
-    all_sorts["code"] = all_sorts.index
-    all_sorts["index"] = all_sorts["index2"]
-    # all_sorts.set_index('index2',inplace=True)
+class ThicknessCalculatorTheta(ThicknessCalculator):
 
-    contacts = pd.read_csv(contact_points_file)
+        def __init__(self):
+            """
+            Initialiser for theta version of the thickness calculator
+            """
+            self.thickness_calculator_label = "ThicknessCalculatorTheta"
 
-    clength = len(contacts)
-    cx = contacts["X"].to_numpy()
-    cy = contacts["Y"].to_numpy()
-    cl = contacts["lsx"].to_numpy(dtype=float)
-    cm = contacts["lsy"].to_numpy(dtype=float)
-    ctextcode = contacts["formation"].to_numpy()
+        def compute(self,
+                    units: pandas.DataFrame,
+                    stratigraphic_order: list,
+                    basal_contacts: pandas.DataFrame,
+                    map_data: MapData,
+                    ) -> pandas.DataFrame:
+            """
+            Args:
+                units (pandas.DataFrame): the data frame of units to add thicknesses to
+                stratigraphic_order (list): a list of unit names sorted from youngest to oldest
+                basal_contacts (geopandas.GeoDataFrame): basal contact geo data with locations and unit names of the contacts (columns must contain ["ID","basal_unit","type","geometry"])
+                map_data (map2loop.MapData): a catchall so that access to all map data is available
 
-    fth = open(os.path.join(config.output_path, "formation_thicknesses.csv"), "w")
-    fth.write(
-        "X,Y,formation,appar_th,thickness,cl,cm,p1x,p1y,p2x,p2y,dip,type,slope_dip,slope_length,delz,zbase,zcross\n"
-    )
-
-    # np.savetxt(os.path.join(config.temporary_path,'dist.csv'),dist,delimiter = ',')
-    # display("ppp",cx.shape,cy.shape,ox.shape,oy.shape,dip.shape,azimuth.shape,dist.shape)
-    n_est = 0
-    for k in range(0, clength):  # loop through all contact segments
-        r = int((cy[k] - config.bbox[1]) / config.run_flags["interpolation_spacing"])
-        c = int((cx[k] - config.bbox[0]) / config.run_flags["interpolation_spacing"])
-
-        dip_mean = map_data.dip_grid[r, c]
-
-        dx1 = -cm[k] * config.run_flags["thickness_buffer"]
-        dy1 = cl[k] * config.run_flags["thickness_buffer"]
-        dx2 = -dx1
-        dy2 = -dy1
-        p1 = Point((dx1 + cx[k], dy1 + cy[k]))
-        p2 = Point((dx2 + cx[k], dy2 + cy[k]))
-        ddline = LineString((p1, p2))
-        orig = Point((cx[k], cy[k]))
-
-        crossings = np.zeros((1000, 5))
-
-        g = 0
-        for indx, apair in all_sorts.iterrows():  # loop through all basal contacts
-            if ctextcode[k] == apair["code"]:
-                # subset contacts to just those with 'a' code
-                is_contacta = (
-                        contact_lines["UNIT_NAME"] == all_sorts.iloc[g - 1]["code"]
-                )
-                acontacts = contact_lines[is_contacta]
-                i = 0
-                for (
-                        ind,
-                        acontact,
-                ) in (
-                        acontacts.iterrows()
-                ):  # loop through distinct linestrings for upper contact
-                    # if(bboxes_intersect(ddline.bounds,acontact[1].geometry.bounds)):
-                    if not str(acontact.geometry) == "None":
-                        if ddline.intersects(acontact.geometry):
-                            isects = ddline.intersection(acontact.geometry)
-                            if isects.geom_type == "MultiPoint":
-                                for pt in isects:
-                                    if (
-                                            pt.distance(orig)
-                                            < config.run_flags["thickness_buffer"] * 2
-                                    ):
-                                        # print(i,",", pt.x, ",",pt.y,",",apair[1]['code'],",",apair[1]['group'])
-                                        crossings[i, 0] = i
-                                        crossings[i, 1] = int(apair["index"])
-                                        crossings[i, 2] = 0
-                                        crossings[i, 3] = pt.x
-                                        crossings[i, 4] = pt.y
-                                        i = i + 1
-                            else:
-                                if (
-                                        isects.distance(orig)
-                                        < config.run_flags["thickness_buffer"] * 2
-                                ):
-                                    # print(i,",", isects.x,",", isects.y,",",apair[1]['code'],",",apair[1]['group'])
-                                    crossings[i, 0] = i
-                                    crossings[i, 1] = int(apair["index"])
-                                    crossings[i, 2] = 0
-                                    crossings[i, 3] = isects.x
-                                    crossings[i, 4] = isects.y
-                                    i = i + 1
-
-                            if (
-                                    i > 0
-                            ):  # if we found any intersections with base of next higher unit
-                                min_dist = 1e8
-                                # min_pt = 0
-                                for f in range(0, i):  # find closest hit
-                                    this_dist = m2l_utils.ptsdist(
-                                        crossings[f, 3], crossings[f, 4], cx[k], cy[k]
-                                    )
-                                    if this_dist < min_dist:
-                                        min_dist = this_dist
-                                        # min_pt = f
-                                        crossx = crossings[f, 3]
-                                        crossy = crossings[f, 4]
-                                # if not too far, add to output
-                                if (
-                                        min_dist < config.run_flags["max_thickness_allowed"]
-                                        and min_dist > 0
-                                ):
-                                    locations = [(cx[k], cy[k])]
-                                    zbase = float(
-                                        m2l_utils.value_from_dtm_dtb(
-                                            dtm, "", "", False, locations
-                                        )
-                                    )
-                                    locations = [(crossx, crossy)]
-                                    zcross = float(
-                                        m2l_utils.value_from_dtm_dtb(
-                                            dtm, "", "", False, locations
-                                        )
-                                    )
-                                    delz = fabs(zcross - zbase)
-                                    slope_dip = degrees(atan(delz / min_dist))
-                                    slope_length = sqrt(
-                                        (min_dist * min_dist) + (delz * delz)
-                                    )
-                                    if slope_dip < dip_mean and zbase > zcross:
-                                        surf_dip = dip_mean - slope_dip
-                                    elif slope_dip < dip_mean and zbase < zcross:
-                                        surf_dip = dip_mean + slope_dip
-                                    elif slope_dip > dip_mean and zbase > zcross:
-                                        surf_dip = slope_dip - dip_mean
-                                    else:
-                                        surf_dip = 180 - (dip_mean + slope_dip)
-
-                                    true_thick = slope_length * sin(radians(surf_dip))
-                                    if (
-                                            not isnan(true_thick)
-                                            and true_thick > 0
-                                            and true_thick
-                                            < config.run_flags["max_thickness_allowed"]
-                                    ):
-                                        ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
-                                            cx[k],
-                                            cy[k],
-                                            ctextcode[k],
-                                            min_dist,
-                                            int(true_thick),
-                                            cl[k],
-                                            cm[k],
-                                            p1.x,
-                                            p1.y,
-                                            p2.x,
-                                            p2.y,
-                                            dip_mean,
-                                            "full",
-                                            slope_dip,
-                                            slope_length,
-                                            delz,
-                                            zbase,
-                                            zcross,
-                                        )
-                                        # ostr = str(cx[k])+','+str(cy[k])+','+ctextcode[k]+','+str(int(true_thick))+\
-                                        #    ','+str(cl[k])+','+str(cm[k])+','+str(lm)+','+str(mm)+','+str(nm)+','+\
-                                        #    str(p1.x)+','+str(p1.y)+','+str(p2.x)+','+str(p2.y)+','+str(dip_mean)+'\n'
-                                        fth.write(ostr)
-                                        n_est = n_est + 1
-
-            g = g + 1
-    if config.verbose_level != VerboseLevel.NONE:
-        print(
-            n_est,
-            "thickness estimates saved as",
-            os.path.join(config.output_path, "formation_thicknesses.csv"),
-        )
-
-
-@beartype.beartype
-def calc_min_thickness_with_grid(config: Config, map_data: MapData):
-    dtm = map_data.get_map_data(Datatype.DTM).open()
-    contact_points_file = os.path.join(config.temporary_path, "raw_contacts.csv")
-    # load basal contacts as geopandas dataframe
-    contact_lines = gpd.read_file(
-        os.path.join(config.temporary_path, "basal_contacts.shp.zip")
-    )
-    all_sorts = pd.read_csv(os.path.join(config.temporary_path, "all_sorts.csv"))
-    contacts = pd.read_csv(contact_points_file)
-
-    sum_thick = pd.read_csv(
-        os.path.join(config.output_path, "formation_thicknesses.csv")
-    )
-    found_codes = sum_thick["formation"].unique()
-    if config.verbose_level != VerboseLevel.NONE:
-        print(found_codes, "already processed")
-    clength = len(contacts)
-    cx = contacts["X"].to_numpy()
-    cy = contacts["Y"].to_numpy()
-    cl = contacts["lsx"].to_numpy(dtype=float)
-    cm = contacts["lsy"].to_numpy(dtype=float)
-    ctextcode = contacts["formation"].to_numpy()
-
-    fth = open(os.path.join(config.output_path, "formation_thicknesses.csv"), "a+")
-    # fth.write('X,Y,formation,appar_th,thickness,cl,cm,p1x,p1y,p2x,p2y,dip\n')
-
-    # np.savetxt(os.path.join(config.temporary_path,'dist.csv'),dist,delimiter = ',')
-    # display("ppp",cx.shape,cy.shape,ox.shape,oy.shape,dip.shape,azimuth.shape,dist.shape)
-    n_est = 0
-    for k in range(0, clength):  # loop through all contact segments
-        if not (ctextcode[k] in found_codes):
-            # print(ctextcode[k])
-            r = int(
-                (cy[k] - config.bbox[1]) / config.run_flags["interpolation_spacing"]
-            )
-            c = int(
-                (cx[k] - config.bbox[0]) / config.run_flags["interpolation_spacing"]
-            )
-
-            dip_mean = map_data.dip_grid[r, c]
-
-            dx1 = -cm[k] * config.run_flags["thickness_buffer"]
-            dy1 = cl[k] * config.run_flags["thickness_buffer"]
-            dx2 = -dx1
-            dy2 = -dy1
-            p1 = Point((dx1 + cx[k], dy1 + cy[k]))
-            p2 = Point((dx2 + cx[k], dy2 + cy[k]))
-            ddline = LineString((p1, p2))
-            orig = Point((cx[k], cy[k]))
-
-            crossings = np.zeros((1000, 5))
-
-            g = 0
-            for indx, apair in all_sorts.iterrows():  # loop through all basal contacts
-                if ctextcode[k] == apair["code"]:
-                    # subset contacts to just those with 'a' code
-                    is_contacta = (
-                            contact_lines["UNIT_NAME"] != all_sorts.iloc[g - 1]["code"]
-                    )
-                    acontacts = contact_lines[is_contacta]
-                    i = 0
-                    for (
-                            ind,
-                            acontact,
-                    ) in (
-                            acontacts.iterrows()
-                    ):  # loop through distinct linestrings for upper contact
-                        # if(bboxes_intersect(ddline.bounds,acontact[1].geometry.bounds)):
-
-                        if not str(acontact.geometry) == "None":
-                            if ddline.intersects(acontact.geometry):
-                                isects = ddline.intersection(acontact.geometry)
-                                if isects.geom_type == "MultiPoint":
-                                    for pt in isects.geoms:
-                                        if (
-                                                pt.distance(orig)
-                                                < config.run_flags["thickness_buffer"] * 2
-                                        ):
-                                            # print(i,",", pt.x, ",",pt.y,",",apair[1]['code'],",",apair[1]['group'])
-                                            crossings[i, 0] = i
-                                            crossings[i, 1] = int(apair["index"])
-                                            crossings[i, 2] = 0
-                                            crossings[i, 3] = pt.x
-                                            crossings[i, 4] = pt.y
-                                            i = i + 1
-                                else:
-                                    if not isects.geom_type == "GeometryCollection":
-                                        if (
-                                                isects.distance(orig)
-                                                < config.run_flags["thickness_buffer"] * 2
-                                        ):
-                                            # print(i,",", isects.x,",", isects.y,",",apair[1]['code'],",",apair[1]['group'])
-                                            crossings[i, 0] = i
-                                            crossings[i, 1] = int(apair["index"])
-                                            crossings[i, 2] = 0
-                                            crossings[i, 3] = isects.x
-                                            crossings[i, 4] = isects.y
-                                            i = i + 1
-
-                                if (
-                                        i > 0
-                                ):  # if we found any intersections with base of next higher unit
-                                    min_dist = 1e8
-                                    # min_pt = 0
-                                    for f in range(0, i):  # find closest hit
-                                        this_dist = m2l_utils.ptsdist(
-                                            crossings[f, 3],
-                                            crossings[f, 4],
-                                            cx[k],
-                                            cy[k],
-                                        )
-                                        if this_dist < min_dist:
-                                            min_dist = this_dist
-                                            # min_pt = f
-                                            crossx = crossings[f, 3]
-                                            crossy = crossings[f, 4]
-                                    # if not too far, add to output
-                                    if (
-                                            min_dist
-                                            < config.run_flags["max_thickness_allowed"]
-                                            and min_dist > 1
-                                    ):
-                                        locations = [(cx[k], cy[k])]
-                                        zbase = float(
-                                            m2l_utils.value_from_dtm_dtb(
-                                                dtm, "", "", False, locations
-                                            )
-                                        )
-                                        locations = [(crossx, crossy)]
-                                        zcross = float(
-                                            m2l_utils.value_from_dtm_dtb(
-                                                dtm, "", "", False, locations
-                                            )
-                                        )
-                                        delz = fabs(zcross - zbase)
-                                        slope_dip = degrees(atan(delz / min_dist))
-                                        slope_length = sqrt(
-                                            (min_dist * min_dist) + (delz * delz)
-                                        )
-                                        if slope_dip < dip_mean and zbase > zcross:
-                                            surf_dip = dip_mean - slope_dip
-                                        elif slope_dip < dip_mean and zbase < zcross:
-                                            surf_dip = dip_mean + slope_dip
-                                        elif slope_dip > dip_mean and zbase > zcross:
-                                            surf_dip = slope_dip - dip_mean
-                                        else:
-                                            surf_dip = 180 - (dip_mean + slope_dip)
-
-                                        true_thick = slope_length * sin(
-                                            radians(surf_dip)
-                                        )
-                                        if (
-                                                not isnan(true_thick)
-                                                and true_thick > 0
-                                                and true_thick
-                                                < config.run_flags["max_thickness_allowed"]
-                                        ):
-                                            ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
-                                                cx[k],
-                                                cy[k],
-                                                ctextcode[k],
-                                                min_dist,
-                                                int(true_thick),
-                                                cl[k],
-                                                cm[k],
-                                                p1.x,
-                                                p1.y,
-                                                p2.x,
-                                                p2.y,
-                                                dip_mean,
-                                                "min",
-                                                slope_dip,
-                                                slope_length,
-                                                delz,
-                                                zbase,
-                                                zcross,
-                                            )
-                                            # ostr = str(cx[k])+','+str(cy[k])+','+ctextcode[k]+','+str(int(true_thick))+\
-                                            #    ','+str(cl[k])+','+str(cm[k])+','+str(lm)+','+str(mm)+','+str(nm)+','+\
-                                            #    str(p1.x)+','+str(p1.y)+','+str(p2.x)+','+str(p2.y)+','+str(dip_mean)+'\n'
-                                            fth.write(ostr)
-                                            n_est = n_est + 1
-
-            g = g + 1
-    if config.verbose_level != VerboseLevel.NONE:
-        print(
-            n_est,
-            "min thickness estimates appended to",
-            os.path.join(config.output_path, "formation_thicknesses.csv"),
-        )
-    fth.close()
-
-
-####################################
-# Normalise thickness for each estimate to median for that formation
-#
-# normalise_thickness(output_path)
-# Args:
-# output_path path to m2l output directory
-#
-# Normalises previously calculated formation thickness by dviding by median value for that formation
-####################################
-def normalise_thickness(output_path):
-    thickness = pd.read_csv(
-        os.path.join(output_path, "formation_thicknesses.csv"), sep=","
-    )
-
-    codes = thickness.formation.unique()
-    f = open(os.path.join(output_path, "formation_thicknesses_norm.csv"), "w")
-    f.write("x,y,formation,app_th,thickness,norm_th\n")
-    fs = open(os.path.join(output_path, "formation_summary_thicknesses.csv"), "w")
-    fs.write("formation,thickness median,thickness std,method\n")
-    for code in codes:
-        is_code = thickness.formation.str.contains(code, regex=False)
-        all_thick = thickness[is_code]
-        all_thick2 = all_thick[all_thick["thickness"] != 0]
-        thicknesses = np.asarray(all_thick2.loc[:, "thickness"], dtype=float)
-
-        if len(all_thick2) > 2:
-            med = np.median(thicknesses)
-            std = np.std(thicknesses)
-            # print(code, med, std)
-            ostr = "{},{},{},{}\n".format(code, med, std, all_thick2.iloc[0]["type"])
-            # ostr = str(code)+","+str(all_thick2.loc[:,"thickness"].median())+","+str(all_thick2.loc[:,"thickness"].std())+"\n"
-            fs.write(ostr)
-
-            thick = all_thick2.to_numpy()
-
-            for i in range(len(thick)):
-                if med > 0:
-                    ostr = "{},{},{},{},{},{}\n".format(
-                        thick[i, 0],
-                        thick[i, 1],
-                        thick[i, 2],
-                        thick[i, 3],
-                        thick[i, 4],
-                        thicknesses[i] / med,
-                    )
-                    # ostr = str(thick[i,0])+","+str(thick[i,1])+","+str(thick[i,2])+","+str(thick[i,3])+","+str(thick[i,3]/med)+"\n"
-                    f.write(ostr)
-    f.close()
-    fs.close()
+            Returns:
+                pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
+            """
+            bounding_box = map_data.bounding_box
+            side_length = bounding_box['maxx'] - bounding_box['minx']
+            # define the spacing of the sampler automatically to 4% of the side length of the bounding box
+            spacing = side_length * 0.04
+            # sample the contacts
+            sampler = SamplerSpacing(spacing)
+            sampled_contacts = sampler.sample(basal_contacts)
+            

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -8,7 +8,10 @@ from statistics import mean
 from .mapdata import MapData
 from map2loop.sampler import SamplerSpacing
 from interpolator import NormalVectorInterpolator, DipInterpolator
-from utils import normal_vector_to_dipdirection_dip
+from utils import normal_vector_to_dipdirection_dip, create_points
+from .m2l_enums import Datatype
+from shapely.ops import nearest_points
+from shapely.geometry import Point, LineString
 
 class ThicknessCalculator(ABC):
     """
@@ -162,7 +165,7 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
 
     def __init__(self):
         """
-        Initialiser for beta version of the thickness calculator
+        Initialiser for theta version of the thickness calculator
         """
         self.thickness_calculator_label = "ThicknessCalculatorBeta"
 
@@ -182,237 +185,76 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
         Returns:
             pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
         """
+        no_distance = -1.0
+        basal_contacts = basal_contacts[basal_contacts["type"] == "BASAL"]
+        thicknesses = units.copy()
+        # Set default value
+        thicknesses["thickness"] = no_distance
+        basal_unit_list = basal_contacts["basal_unit"].to_list()
+        # 1. calculate $spacing using bounding box
+        # bounding_box = map_data.bounding_box
+        # side_length = bounding_box['maxx'] - bounding_box['minx']
+        # # define the spacing of the sampler automatically to 4% of the side length of the bounding box
+        # spacing = side_length * 0.04
+        # # # 2. Sample $basal_contacts using $spacing
+        # sampler = SamplerSpacing(spacing)
+        # sampled_contacts = map_data.sampled_contacts
+        # 4. interpolate orientation data using bounding box
+        interpolator = NormalVectorInterpolator()
+        normal_vectors = interpolator.interpolate(map_data)
+        # convert normal vectors to dip and dip direction
+        dip, dip_direction = normal_vector_to_dipdirection_dip(normal_vectors[:, 0],
+                                                               normal_vectors[:, 1],
+                                                               normal_vectors[:, 2])
+        interp_dataframe = geopandas.GeoDataFrame()
+        interp_dataframe["dip"] = dip
+        interp_dataframe["dip_direction"] = dip_direction
+        xy = numpy.array([interpolator.xi, interpolator.yi]).T
+        interp_dataframe["geometry"] = create_points(xy)
+        # 5. For each interpolated point, assign name of unit using spatial join
+        units = map_data.get_map_data(Datatype.GEOLOGY)
+        interp_dataframe = interp_dataframe.sjoin(units, how="inner", op="within")
+        interp_dataframe = interp_dataframe[["geometry", "DIPDIR", "DIP", "ID_left", "UNITNAME"]].copy()
+        interp_dataframe['nearest_point'] = None
 
-        # def calc_thickness(temporary_path, output_path, buffer, max_thickness_allowed, c_l):
-        """
-        This function calculates the thickness of geological units based on various data inputs.
+        if len(stratigraphic_order) < 3:
+            print(
+                f"Cannot make any thickness calculations with only {len(stratigraphic_order)} units"
+            )
+            return thicknesses
+        for i in range(1, len(stratigraphic_order) - 1):
+            # Compare basal contacts of adjacent units
+            if (
+                    stratigraphic_order[i] in basal_unit_list
+                    and stratigraphic_order[i + 1] in basal_unit_list
+            ):
+                basal_contact = interp_dataframe[
+                    interp_dataframe["basal_unit"] == stratigraphic_order[i]
+                    ]["geometry"]
+                top_contact = interp_dataframe[
+                    interp_dataframe["basal_unit"] == stratigraphic_order[i + 1]
+                    ]["geometry"]
 
-        Parameters:
-        temporary_path (str): The temporary path where the data files are located.
-        output_path (str): The path where the output file will be saved.
-        buffer (float): The buffer distance for identifying close points.
-        max_thickness_allowed (float): The maximum allowed thickness for a geological unit.
-        c_l (dict): A dictionary containing configuration parameters.
-
-        Returns:
-        None: The function writes the results to an output file and does not return anything.
-        """
-        # TODO: find a way to use sampled contacts - stratigraphyLocations?
-        # Load the contact points and interpolated data from the temporary path
-        # contact_points_file = os.path.join(temporary_path, "raw_contacts.csv")
-        contact_points_file = map_data.contacts
-        # TODO: implement interpolation code
-        # interpolated_combo_file = os.path.join(temporary_path, "combo_full.csv")
-
-        # Load the basal contacts as a geopandas dataframe
-        # basal_contacts = geopandas.read_file(os.path.join(temporary_path, "/basal_contacts.shp.zip"))
-
-        # Load the sorted data
-        all_sorts = pandas.read_csv(os.path.join(temporary_path, "all_sorts.csv"))
-
-        # Load the contacts and orientations data
-        contacts = pandas.read_csv(contact_points_file)
-        orientations = pandas.read_csv(interpolated_combo_file)
-
-        # Get the length of the orientations and contacts data
-        olength = len(orientations)
-        clength = len(contacts)
-
-        # Convert the X and Y coordinates, the slope of the line segment, and the formation name to numpy arrays
-        cx = contacts["X"].to_numpy()
-        cy = contacts["Y"].to_numpy()
-        cl = contacts["lsx"].to_numpy(dtype=float)
-        cm = contacts["lsy"].to_numpy(dtype=float)
-        ctextcode = contacts["formation"].to_numpy()
-
-        # Convert the X and Y coordinates, the dip and azimuth to numpy arrays
-        ox = orientations["X"].to_numpy()
-        oy = orientations["Y"].to_numpy()
-        dip = orientations["dip"].to_numpy().reshape(olength, 1)
-        azimuth = orientations["azimuth"].to_numpy().reshape(olength, 1)
-
-        # Initialize arrays for the direction cosines
-        l = numpy.zeros(len(ox))
-        m = numpy.zeros(len(ox))
-        n = numpy.zeros(len(ox))
-
-        # Open the output file and write the header
-        file = open(os.path.join(output_path, "formation_thicknesses.csv"), "w")
-        file.write(
-            "X,Y,formation,appar_th,thickness,cl,cm,meanl,meanm,meann,p1x,p1y,p2x,p2y,dip\n"
-        )
-
-        # Calculate the distance matrix
-        dist = m2l_interpolation.distance_matrix(ox, oy, cx, cy)
-
-        # Initialize the counter for the number of thickness estimates
-        n_est = 0
-
-        # Loop through all contact segments
-        for k in range(0, clength):
-            # Calculate the distance to all other points and identify those within the buffer distance
-            a_dist = dist[:, k: k + 1]
-            is_close = a_dist < buffer
-            close_dip = dip[is_close]
-            close_azimuth = azimuth[is_close]
-
-            # Initialize the counter for the number of good candidates
-            n_good = 0
-
-            # Find the averaged dips within the buffer
-            for j in range(0, len(close_dip)):
-                l[n_good], m[n_good], n[n_good] = m2l_utils.ddd2dircos(
-                    float(close_dip[j]), float(close_azimuth[j]) + 90.0
+                if basal_contact is not None and top_contact is not None:
+                    # distance = contact1.distance(contact2)
+                    for j, row in basal_contact.iterrows():
+                        # Create unary union
+                        unary_union = top_contact.unary_union
+                        nearest = nearest_points(row.geometry, unary_union)
+                        interp_dataframe.loc[j, 'nearest_point'] = nearest[1]
+                        interp_dataframe.loc[j, 'line'] = LineString([row.geometry, nearest[1]])
+                else:
+                    print(
+                        f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
+                    )
+                    distance = no_distance
+            else:
+                print(
+                    f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                 )
-                n_good = n_good + 1
 
-            # If we found any candidates, calculate the average direction cosine of points within the buffer range
-            if n_good > 0:
-                lm = numpy.mean(l[:n_good])
-                mm = numpy.mean(m[:n_good])
-                nm = numpy.mean(n[:n_good])
-                dip_mean, dipdirection_mean = m2l_utils.dircos2ddd(lm, mm, nm)
-
-                # Create a line segment perpendicular to the contact point
-                dx1 = -cm[k] * buffer
-                dy1 = cl[k] * buffer
-                dx2 = -dx1
-                dy2 = -dy1
-                p1 = Point((dx1 + cx[k], dy1 + cy[k]))
-                p2 = Point((dx2 + cx[k], dy2 + cy[k]))
-                ddline = LineString((p1, p2))
-                orig = Point((cx[k], cy[k]))
-
-                # Initialize the crossings array
-                crossings = numpy.zeros((1000, 5))
-
-                # Loop through all basal contacts
-                g = 0
-                for indx, apair in all_sorts.iterrows():
-                    if ctextcode[k] == apair["code"]:
-                        # Subset contacts to just those with 'a' code
-                        is_contacta = (
-                                basal_contacts["UNIT_NAME"] == all_sorts.iloc[g - 1]["code"]
-                        )
-                        acontacts = basal_contacts[is_contacta]
-                        i = 0
-
-                        # Loop through distinct linestrings for upper contact
-                        for ind, acontact in acontacts.iterrows():
-                            if not str(acontact.geometry) == "None":
-                                if ddline.intersects(acontact.geometry):
-                                    isects = ddline.intersection(acontact.geometry)
-
-                                    # If the intersection is a MultiPoint, loop through all points
-                                    if isects.geom_type == "MultiPoint":
-                                        for pt in isects:
-                                            if pt.distance(orig) < buffer * 2:
-                                                crossings[i, 0] = i
-                                                crossings[i, 1] = int(apair["index"])
-                                                crossings[i, 2] = 0
-                                                crossings[i, 3] = pt.x
-                                                crossings[i, 4] = pt.y
-                                                i = i + 1
-                                    else:
-                                        if isects.distance(orig) < buffer * 2:
-                                            crossings[i, 0] = i
-                                            crossings[i, 1] = int(apair["index"])
-                                            crossings[i, 2] = 0
-                                            crossings[i, 3] = isects.x
-                                            crossings[i, 4] = isects.y
-                                            i = i + 1
-
-                                    # If we found any intersections with the base of the next higher unit
-                                    if i > 0:
-                                        min_dist = 1e8
-                                        for f in range(0, i):  # find closest hit
-                                            this_dist = m2l_utils.ptsdist(
-                                                crossings[f, 3],
-                                                crossings[f, 4],
-                                                cx[k],
-                                                cy[k],
-                                            )
-                                            if this_dist < min_dist:
-                                                min_dist = this_dist
-
-                                        # If the minimum distance is not too far, add to output
-                                        if min_dist < max_thickness_allowed:
-                                            true_thick = sin(radians(dip_mean)) * min_dist
-                                            ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
-                                                cx[k],
-                                                cy[k],
-                                                ctextcode[k],
-                                                min_dist,
-                                                int(true_thick),
-                                                cl[k],
-                                                cm[k],
-                                                lm,
-                                                mm,
-                                                nm,
-                                                p1.x,
-                                                p1.y,
-                                                p2.x,
-                                                p2.y,
-                                                dip_mean,
-                                            )
-                                            file.write(ostr)
-                                            n_est = n_est + 1
-
-                    g = g + 1
-
-        # Print the number of thickness estimates that were saved to the output file
-        print(
-            n_est,
-            "thickness estimates saved as",
-            os.path.join(output_path, "formation_thicknesses.csv"),
-        )
-
-
-class ThicknessCalculatorTheta(ThicknessCalculator):
-
-        def __init__(self):
-            """
-            Initialiser for theta version of the thickness calculator
-            """
-            self.thickness_calculator_label = "ThicknessCalculatorTheta"
-
-        def compute(self,
-                    units: pandas.DataFrame,
-                    stratigraphic_order: list,
-                    basal_contacts: pandas.DataFrame,
-                    map_data: MapData,
-                    ) -> pandas.DataFrame:
-            """
-            Args:
-                units (pandas.DataFrame): the data frame of units to add thicknesses to
-                stratigraphic_order (list): a list of unit names sorted from youngest to oldest
-                basal_contacts (geopandas.GeoDataFrame): basal contact geo data with locations and unit names of the contacts (columns must contain ["ID","basal_unit","type","geometry"])
-                map_data (map2loop.MapData): a catchall so that access to all map data is available
-
-            Returns:
-                pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
-            """
-            # 1. calculate $spacing using bounding box
-            bounding_box = map_data.bounding_box
-            side_length = bounding_box['maxx'] - bounding_box['minx']
-            # define the spacing of the sampler automatically to 4% of the side length of the bounding box
-            spacing = side_length * 0.04
-            # # 2. Sample $basal_contacts using $spacing
-            sampler = SamplerSpacing(spacing)
-            sampled_contacts = sampler.sample(basal_contacts)
-            # 4. interpolate orientation data using bounding box
-            interpolator = NormalVectorInterpolator()
-            normal_vectors = interpolator.interpolate(map_data)
-            # convert normal vectors to dip and dip direction
-            dip, dip_direction = normal_vector_to_dipdirection_dip(normal_vectors[:, 0],
-                                                                   normal_vectors[:, 1],
-                                                                   normal_vectors[:, 2])
-
-            # 5. For each unit, assign name of unit to $basal_contact
-            # 6. calculate the nearest neighbours between base and top of unit in the stratigraphic order
-            # 7. select the nearest neighbour of each basal point and their distance to the top point
-            # 8. calculate the nearest neighbour between orientation data and basal points and top points
-            # 9. calculate angle ρ = cos–1 {[(x1 – x2) / L] sinθb sinδb + [(y1 – y2) / L] cosθb sinδb + [(z2 – z1) / L] cosδb} / L : is the distance between basal and top points
-            # 10. Calculate true thickness t = L . cos ρ
-
-
+        # 6. calculate the nearest neighbours between base and top of unit in the stratigraphic order
+        # 7. select the nearest neighbour of each basal point and their distance to the top point
+        # 8. calculate the nearest neighbour between orientation data and basal points and top points
+        # 9. calculate angle ρ = cos–1 {[(x1 – x2) / L] sinθb sinδb + [(y1 – y2) / L] cosθb sinδb + [(z2 – z1) / L] cosδb} / L : is the distance between basal and top points
+        # 10. Calculate true thickness t = L . cos ρ

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -12,6 +12,8 @@ from utils import normal_vector_to_dipdirection_dip, create_points
 from .m2l_enums import Datatype
 from shapely.ops import nearest_points
 from shapely.geometry import Point, LineString
+from shapely import shortest_line, dwithin, length
+
 
 class ThicknessCalculator(ABC):
     """
@@ -157,12 +159,35 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
         )
         return thicknesses
 
-    # TODO: use S-Tree to find intersections,
-    # and K-D tree to find nearest points for efficient computations
-
 
 class ThicknessCalculatorBeta(ThicknessCalculator):
+    """
+    This class is a subclass of the ThicknessCalculator abstract base class. It implements the thickness calculation
+    method for a given set of data points. The class is initialized without any arguments.
 
+    Attributes:
+        thickness_calculator_label (str): A string that stores the label of the thickness calculator.
+        For this class, it is "ThicknessCalculatorBeta".
+
+    Methods:
+        compute(units: pandas.DataFrame, stratigraphic_order: list, basal_contacts: pandas.DataFrame, map_data: MapData)
+        -> pandas.DataFrame:
+        Calculates a thickness map for the overall map area.
+    """
+    def __init__(self):
+        """
+        Initialiser for beta version of the thickness calculator
+        """
+        self.thickness_calculator_label = "ThicknessCalculatorBeta"
+
+    def compute(self,
+                units: pandas.DataFrame,
+                stratigraphic_order: list,
+                basal_contacts: pandas.DataFrame,
+                map_data: MapData,
+                ) -> pandas.DataFrame:
+
+        # The rest of the code...
     def __init__(self):
         """
         Initialiser for theta version of the thickness calculator
@@ -176,6 +201,11 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
                 map_data: MapData,
                 ) -> pandas.DataFrame:
         """
+
+        Execute thickness calculator method takes unit data, basal_contacts, stratigraphic order, orientation data and
+        DTM data to estimate a thickness map.
+        # TODO: need to find better approach to calculate thickness for top and bottom units
+
         Args:
             units (pandas.DataFrame): the data frame of units to add thicknesses to
             stratigraphic_order (list): a list of unit names sorted from youngest to oldest
@@ -185,76 +215,127 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
         Returns:
             pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
         """
+        #TODO: find a way to provide either average thickness for each unit
         no_distance = -1.0
         basal_contacts = basal_contacts[basal_contacts["type"] == "BASAL"]
         thicknesses = units.copy()
         # Set default value
         thicknesses["thickness"] = no_distance
         basal_unit_list = basal_contacts["basal_unit"].to_list()
-        # 1. calculate $spacing using bounding box
-        # bounding_box = map_data.bounding_box
-        # side_length = bounding_box['maxx'] - bounding_box['minx']
-        # # define the spacing of the sampler automatically to 4% of the side length of the bounding box
-        # spacing = side_length * 0.04
-        # # # 2. Sample $basal_contacts using $spacing
-        # sampler = SamplerSpacing(spacing)
-        # sampled_contacts = map_data.sampled_contacts
-        # 4. interpolate orientation data using bounding box
+        # increase buffer around basal contacts to ensure that the points are included as intersections
+        basal_contacts['geometry'] = basal_contacts['geometry'].buffer(0.01)
+        # TODO: it's better to access the straphigraphyLocations directly from the map_data object
+        # get the sampled contacts
+        contacts = geopandas.GeoDataFrame(map_data.sampled_contacts)
+        # build points from x and y coordinates
+        contacts['geometry'] = contacts.apply(lambda row: Point(row.X, row.Y), axis=1)
+        # set the crs of the contacts to the crs of the units
+        contacts = contacts.set_crs(crs=units.crs)
+        # get the elevation Z of the contacts
+        contacts = map_data.get_value_from_raster_df(Datatype.DTM, contacts)
+        # update the geometry of the contact points to include the Z value
+        contacts['geometry'] = contacts.apply(lambda row: Point(row.geometry.x, row.geometry.y, row['Z']), axis=1)
+        # spatial join the contact points with the basal contacts to get the unit for each contact point
+        contacts = contacts.sjoin(basal_contacts, how='inner', predicate='intersects')
+        # interpolate orientation data using bounding box
         interpolator = NormalVectorInterpolator()
         normal_vectors = interpolator.interpolate(map_data)
-        # convert normal vectors to dip and dip direction
+        # convert interpolated normal vectors to dip and dip direction
         dip, dip_direction = normal_vector_to_dipdirection_dip(normal_vectors[:, 0],
                                                                normal_vectors[:, 1],
                                                                normal_vectors[:, 2])
-        interp_dataframe = geopandas.GeoDataFrame()
-        interp_dataframe["dip"] = dip
-        interp_dataframe["dip_direction"] = dip_direction
+        # create a GeoDataFrame of the interpolated orientations
+        interpolated_orientations = geopandas.GeoDataFrame()
+        # add the dip and dip direction to the GeoDataFrame
+        interpolated_orientations["dip"] = dip
+        interpolated_orientations["dip_direction"] = dip_direction
+        # get the x and y coordinates of the interpolated points
         xy = numpy.array([interpolator.xi, interpolator.yi]).T
-        interp_dataframe["geometry"] = create_points(xy)
-        # 5. For each interpolated point, assign name of unit using spatial join
-        units = map_data.get_map_data(Datatype.GEOLOGY)
-        interp_dataframe = interp_dataframe.sjoin(units, how="inner", op="within")
-        interp_dataframe = interp_dataframe[["geometry", "DIPDIR", "DIP", "ID_left", "UNITNAME"]].copy()
-        interp_dataframe['nearest_point'] = None
+        # create Point objects from the x and y coordinates
+        interpolated_orientations["geometry"] = create_points(xy)
+        # set the crs of the interpolated orientations to the crs of the units
+        interpolated_orientations = interpolated_orientations.set_crs(crs=units.crs)
+        # get the elevation Z of the interpolated points
+        interpolated = map_data.get_value_from_raster_df(Datatype.DTM, interpolated_orientations)
+        # update the geometry of the interpolated points to include the Z value
+        interpolated['geometry'] = interpolated.apply(
+            lambda row: Point(row.geometry.x, row.geometry.y, row['Z']), axis=1)
+        # for each interpolated point, assign name of unit using spatial join
+        interpolated_orientations = interpolated_orientations.sjoin(units, how="inner", op="within")
+        interpolated_orientations = interpolated_orientations[
+            ["geometry", "dipdir", "dip", "ID_left", "UNITNAME"]].copy()
 
         if len(stratigraphic_order) < 3:
             print(
                 f"Cannot make any thickness calculations with only {len(stratigraphic_order)} units"
             )
             return thicknesses
+
+        thickness_dataframes = []
+
         for i in range(1, len(stratigraphic_order) - 1):
             # Compare basal contacts of adjacent units
             if (
                     stratigraphic_order[i] in basal_unit_list
                     and stratigraphic_order[i + 1] in basal_unit_list
             ):
-                basal_contact = interp_dataframe[
-                    interp_dataframe["basal_unit"] == stratigraphic_order[i]
+                basal_contact = contacts[
+                    contacts["basal_unit"] == stratigraphic_order[i]
                     ]["geometry"]
-                top_contact = interp_dataframe[
-                    interp_dataframe["basal_unit"] == stratigraphic_order[i + 1]
+                top_contact = contacts[
+                    contacts["basal_unit"] == stratigraphic_order[i + 1]
                     ]["geometry"]
 
                 if basal_contact is not None and top_contact is not None:
                     # distance = contact1.distance(contact2)
+                    interp_points = interpolated_orientations.loc[
+                        interpolated_orientations["UNITNAME"] == basal_contact["basal_unit"], "geometry"].copy()
+                    x = numpy.array([point.x for point in interp_points])
+                    y = numpy.array([point.y for point in interp_points])
+                    interp_orientations = interpolated_orientations.loc[
+                        interpolated_orientations["UNITNAME"] == basal_contact["basal_unit"], ["dip", "dipdir"]].copy()
+
                     for j, row in basal_contact.iterrows():
-                        # Create unary union
-                        unary_union = top_contact.unary_union
-                        nearest = nearest_points(row.geometry, unary_union)
-                        interp_dataframe.loc[j, 'nearest_point'] = nearest[1]
-                        interp_dataframe.loc[j, 'line'] = LineString([row.geometry, nearest[1]])
+                        # Storage dataframe
+                        dataframe = pandas.DataFrame()
+                        # 6. find the shortest line between the basal contact points and top contact points
+                        short_line = shortest_line(row.geometry, top_contact)
+                        # calculate the length of the shortest line
+                        _length = length(short_line)
+                        # find the indices of the points that are within 5% of the length of the shortest line
+                        indices = numpy.array(dwithin(short_line, interp_points, _length * 0.05))
+                        # store the x and y coordinates of the points that are within
+                        # 5% of the length of the shortest line
+                        dataframe[i, 'X'] = x[indices]
+                        dataframe[i, 'Y'] = y[indices]
+                        # get the dip and dip direction of the points that are within
+                        # 5% of the length of the shortest line
+                        dip = numpy.deg2rad(interp_orientations['dip'].to_numpy()[indices])
+                        dipdir = numpy.deg2rad(interp_orientations['dipdir'].to_numpy()[indices])
+                        # get the end points of the shortest line
+                        end_point = short_line.coords[-1]
+                        end_x, end_y, end_z = end_point
+                        # calculate the angle ρ
+                        p = numpy.arccos(
+                            ((row.X - end_x) / _length) * numpy.sin(dipdir) * numpy.sin(dip) +
+                            ((row.Y - end_y) / _length) * numpy.cos(dipdir) * numpy.sin(dip) +
+                            ((row.Z - end_z) / _length) * numpy.cos(dip)
+                        )
+                        # calculate the true thickness t = L . cos ρ
+                        thickness = numpy.abs(_length * numpy.cos(p))
+                        # store the thickness in the dataframe
+                        dataframe[i, 'thickness'] = thickness
+                        # store the dataframe in a thickness_dataframes list
+                        thickness_dataframes.append(dataframe)
                 else:
                     print(
                         f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                     )
-                    distance = no_distance
+                    # distance = no_distance
             else:
                 print(
                     f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                 )
 
-        # 6. calculate the nearest neighbours between base and top of unit in the stratigraphic order
-        # 7. select the nearest neighbour of each basal point and their distance to the top point
-        # 8. calculate the nearest neighbour between orientation data and basal points and top points
-        # 9. calculate angle ρ = cos–1 {[(x1 – x2) / L] sinθb sinδb + [(y1 – y2) / L] cosθb sinδb + [(z2 – z1) / L] cosδb} / L : is the distance between basal and top points
-        # 10. Calculate true thickness t = L . cos ρ
+        thicknesses = pandas.concat(thickness_dataframes, axis=1)
+        return thicknesses

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -196,7 +196,7 @@ class ThicknessCalculatorBeta(ThicknessCalculator):
         DTM data to estimate unit thickness.
 
         The method works by iterating over the stratigraphic order of units. For each unit, it finds the basal contact
-        points and the top contact points. It then calculates the shortest line between these points. For each basal
+        points and the top contact line. It then calculates the shortest line between these points. For each basal
         contact point, it finds the interpolated points that are within 10% of the length of the shortest line. It then
         calculates the true thickness of the unit at these points using the formula t = L . sin dip, where L is the
         length of the line orthogonal to both contacts and dip is the dip of the interpolated points.

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import beartype
+import numpy
 import pandas
 import geopandas
 from statistics import mean
@@ -32,11 +33,11 @@ class ThicknessCalculator(ABC):
     @beartype.beartype
     @abstractmethod
     def compute(
-        self,
-        units: pandas.DataFrame,
-        stratigraphic_order: list,
-        basal_contacts: geopandas.GeoDataFrame,
-        map_data: MapData,
+            self,
+            units: pandas.DataFrame,
+            stratigraphic_order: list,
+            basal_contacts: geopandas.GeoDataFrame,
+            map_data: MapData,
     ) -> pandas.DataFrame:
         """
         Execute thickness calculator method (abstract method)
@@ -66,11 +67,11 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
 
     @beartype.beartype
     def compute(
-        self,
-        units: pandas.DataFrame,
-        stratigraphic_order: list,
-        basal_contacts: pandas.DataFrame,
-        map_data: MapData,
+            self,
+            units: pandas.DataFrame,
+            stratigraphic_order: list,
+            basal_contacts: pandas.DataFrame,
+            map_data: MapData,
     ) -> pandas.DataFrame:
         """
         Execute thickness calculator method takes unit data, basal_contacts and stratigraphic order and attempts to estimate unit thickness.
@@ -101,25 +102,25 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
         for i in range(1, len(stratigraphic_order) - 1):
             # Compare basal contacts of adjacent units
             if (
-                stratigraphic_order[i] in basal_unit_list
-                and stratigraphic_order[i + 1] in basal_unit_list
+                    stratigraphic_order[i] in basal_unit_list
+                    and stratigraphic_order[i + 1] in basal_unit_list
             ):
                 contact1 = basal_contacts[
                     basal_contacts["basal_unit"] == stratigraphic_order[i]
-                ]["geometry"].to_list()[0]
+                    ]["geometry"].to_list()[0]
                 contact2 = basal_contacts[
                     basal_contacts["basal_unit"] == stratigraphic_order[i + 1]
-                ]["geometry"].to_list()[0]
+                    ]["geometry"].to_list()[0]
                 if contact1 is not None and contact2 is not None:
                     distance = contact1.distance(contact2)
                 else:
                     print(
-                        f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i+1]}"
+                        f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                     )
                     distance = no_distance
             else:
                 print(
-                    f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i+1]}"
+                    f"Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}"
                 )
 
                 distance = no_distance
@@ -128,7 +129,7 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
             # Find row in unit_dataframe corresponding to unit and replace thickness value if it is -1 or larger than distance
             idx = thicknesses.index[
                 thicknesses["name"] == stratigraphic_order[i]
-            ].tolist()[0]
+                ].tolist()[0]
             if thicknesses.loc[idx, "thickness"] == -1:
 
                 val = distance
@@ -149,3 +150,651 @@ class ThicknessCalculatorAlpha(ThicknessCalculator):
             axis=1,
         )
         return thicknesses
+
+    # TODO: use S-Tree to find intersections,
+    # and K-D tree to find nearest points for efficient computations
+
+
+class ThicknessCalculatorBeta(ThicknessCalculator):
+
+    def __init__(self):
+        """
+        Initialiser for beta version of the thickness calculator
+        """
+        self.thickness_calculator_label = "ThicknessCalculatorBeta"
+
+    def compute(self,
+                units: pandas.DataFrame,
+                stratigraphic_order: list,
+                basal_contacts: pandas.DataFrame,
+                map_data: MapData,
+                ) -> pandas.DataFrame:
+        """
+        Args:
+            units (pandas.DataFrame): the data frame of units to add thicknesses to
+            stratigraphic_order (list): a list of unit names sorted from youngest to oldest
+            basal_contacts (geopandas.GeoDataFrame): basal contact geo data with locations and unit names of the contacts (columns must contain ["ID","basal_unit","type","geometry"])
+            map_data (map2loop.MapData): a catchall so that access to all map data is available
+
+        Returns:
+            pandas.DataFrame: units dataframe with added thickness column for calculated thickness values
+        """
+
+        # def calc_thickness(tmp_path, output_path, buffer, max_thickness_allowed, c_l):
+        """
+        This function calculates the thickness of geological units based on various data inputs.
+
+        Parameters:
+        tmp_path (str): The temporary path where the data files are located.
+        output_path (str): The path where the output file will be saved.
+        buffer (float): The buffer distance for identifying close points.
+        max_thickness_allowed (float): The maximum allowed thickness for a geological unit.
+        c_l (dict): A dictionary containing configuration parameters.
+
+        Returns:
+        None: The function writes the results to an output file and does not return anything.
+        """
+
+        # Load the contact points and interpolated data from the temporary path
+        contact_points_file = os.path.join(tmp_path, "raw_contacts.csv")
+        interpolated_combo_file = os.path.join(tmp_path, "combo_full.csv")
+
+        # Load the basal contacts as a geopandas dataframe
+
+        contact_lines = geopandas.read_file(os.path.join(tmp_path, "/basal_contacts.shp.zip"))
+
+        # Load the sorted data
+        all_sorts = pandas.read_csv(os.path.join(tmp_path, "all_sorts.csv"))
+
+        # Load the contacts and orientations data
+        contacts = pandas.read_csv(contact_points_file)
+        orientations = pandas.read_csv(interpolated_combo_file)
+
+        # Get the length of the orientations and contacts data
+        olength = len(orientations)
+        clength = len(contacts)
+
+        # Convert the X and Y coordinates, the slope of the line segment, and the formation name to numpy arrays
+        cx = contacts["X"].to_numpy()
+        cy = contacts["Y"].to_numpy()
+        cl = contacts["lsx"].to_numpy(dtype=float)
+        cm = contacts["lsy"].to_numpy(dtype=float)
+        ctextcode = contacts["formation"].to_numpy()
+
+        # Convert the X and Y coordinates, the dip and azimuth to numpy arrays
+        ox = orientations["X"].to_numpy()
+        oy = orientations["Y"].to_numpy()
+        dip = orientations["dip"].to_numpy().reshape(olength, 1)
+        azimuth = orientations["azimuth"].to_numpy().reshape(olength, 1)
+
+        # Initialize arrays for the direction cosines
+        l = numpy.zeros(len(ox))
+        m = numpy.zeros(len(ox))
+        n = numpy.zeros(len(ox))
+
+        # Open the output file and write the header
+        file = open(os.path.join(output_path, "formation_thicknesses.csv"), "w")
+        file.write(
+            "X,Y,formation,appar_th,thickness,cl,cm,meanl,meanm,meann,p1x,p1y,p2x,p2y,dip\n"
+        )
+
+        # Calculate the distance matrix
+        dist = m2l_interpolation.distance_matrix(ox, oy, cx, cy)
+
+        # Initialize the counter for the number of thickness estimates
+        n_est = 0
+
+        # Loop through all contact segments
+        for k in range(0, clength):
+            # Calculate the distance to all other points and identify those within the buffer distance
+            a_dist = dist[:, k: k + 1]
+            is_close = a_dist < buffer
+            close_dip = dip[is_close]
+            close_azimuth = azimuth[is_close]
+
+            # Initialize the counter for the number of good candidates
+            n_good = 0
+
+            # Find the averaged dips within the buffer
+            for j in range(0, len(close_dip)):
+                l[n_good], m[n_good], n[n_good] = m2l_utils.ddd2dircos(
+                    float(close_dip[j]), float(close_azimuth[j]) + 90.0
+                )
+                n_good = n_good + 1
+
+            # If we found any candidates, calculate the average direction cosine of points within the buffer range
+            if n_good > 0:
+                lm = numpy.mean(l[:n_good])
+                mm = numpy.mean(m[:n_good])
+                nm = numpy.mean(n[:n_good])
+                dip_mean, dipdirection_mean = m2l_utils.dircos2ddd(lm, mm, nm)
+
+                # Create a line segment perpendicular to the contact point
+                dx1 = -cm[k] * buffer
+                dy1 = cl[k] * buffer
+                dx2 = -dx1
+                dy2 = -dy1
+                p1 = Point((dx1 + cx[k], dy1 + cy[k]))
+                p2 = Point((dx2 + cx[k], dy2 + cy[k]))
+                ddline = LineString((p1, p2))
+                orig = Point((cx[k], cy[k]))
+
+                # Initialize the crossings array
+                crossings = numpy.zeros((1000, 5))
+
+                # Loop through all basal contacts
+                g = 0
+                for indx, apair in all_sorts.iterrows():
+                    if ctextcode[k] == apair["code"]:
+                        # Subset contacts to just those with 'a' code
+                        is_contacta = (
+                                contact_lines["UNIT_NAME"] == all_sorts.iloc[g - 1]["code"]
+                        )
+                        acontacts = contact_lines[is_contacta]
+                        i = 0
+
+                        # Loop through distinct linestrings for upper contact
+                        for ind, acontact in acontacts.iterrows():
+                            if not str(acontact.geometry) == "None":
+                                if ddline.intersects(acontact.geometry):
+                                    isects = ddline.intersection(acontact.geometry)
+
+                                    # If the intersection is a MultiPoint, loop through all points
+                                    if isects.geom_type == "MultiPoint":
+                                        for pt in isects:
+                                            if pt.distance(orig) < buffer * 2:
+                                                crossings[i, 0] = i
+                                                crossings[i, 1] = int(apair["index"])
+                                                crossings[i, 2] = 0
+                                                crossings[i, 3] = pt.x
+                                                crossings[i, 4] = pt.y
+                                                i = i + 1
+                                    else:
+                                        if isects.distance(orig) < buffer * 2:
+                                            crossings[i, 0] = i
+                                            crossings[i, 1] = int(apair["index"])
+                                            crossings[i, 2] = 0
+                                            crossings[i, 3] = isects.x
+                                            crossings[i, 4] = isects.y
+                                            i = i + 1
+
+                                    # If we found any intersections with the base of the next higher unit
+                                    if i > 0:
+                                        min_dist = 1e8
+                                        for f in range(0, i):  # find closest hit
+                                            this_dist = m2l_utils.ptsdist(
+                                                crossings[f, 3],
+                                                crossings[f, 4],
+                                                cx[k],
+                                                cy[k],
+                                            )
+                                            if this_dist < min_dist:
+                                                min_dist = this_dist
+
+                                        # If the minimum distance is not too far, add to output
+                                        if min_dist < max_thickness_allowed:
+                                            true_thick = sin(radians(dip_mean)) * min_dist
+                                            ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
+                                                cx[k],
+                                                cy[k],
+                                                ctextcode[k],
+                                                min_dist,
+                                                int(true_thick),
+                                                cl[k],
+                                                cm[k],
+                                                lm,
+                                                mm,
+                                                nm,
+                                                p1.x,
+                                                p1.y,
+                                                p2.x,
+                                                p2.y,
+                                                dip_mean,
+                                            )
+                                            file.write(ostr)
+                                            n_est = n_est + 1
+
+                    g = g + 1
+
+        # Print the number of thickness estimates that were saved to the output file
+        print(
+            n_est,
+            "thickness estimates saved as",
+            os.path.join(output_path, "formation_thicknesses.csv"),
+        )
+
+
+@beartype.beartype
+def calc_thickness_with_grid(config: Config, map_data: MapData):
+    contact_points_file = os.path.join(config.tmp_path, "raw_contacts.csv")
+    dtm = map_data.get_map_data(Datatype.DTM).open()
+    # load basal contacts as geopandas dataframe
+    contact_lines = gpd.read_file(
+        os.path.join(config.tmp_path, "basal_contacts.shp.zip")
+    )
+    all_sorts = pd.read_csv(os.path.join(config.tmp_path, "all_sorts.csv"))
+    all_sorts["index2"] = all_sorts.index
+    # all_sorts.set_index('code',inplace=True)
+    geol = map_data.get_map_data(Datatype.GEOLOGY).copy()
+    # geol=gpd.read_file(os.path.join(config.tmp_path, 'geol_clip.shp'))
+    geol.drop_duplicates(subset="UNIT_NAME", inplace=True)
+    # geol.set_index('UNIT_NAME',inplace=True)
+    drops = geol[
+        geol["DESCRIPTION"].str.contains(config.c_l["sill"])
+        & geol["ROCKTYPE1"].str.contains(config.c_l["intrusive"])
+        ]
+    for ind, drop in drops.iterrows():
+        all_sorts.drop(labels=drop.name, inplace=True, errors="ignore")
+    all_sorts["code"] = all_sorts.index
+    all_sorts["index"] = all_sorts["index2"]
+    # all_sorts.set_index('index2',inplace=True)
+
+    contacts = pd.read_csv(contact_points_file)
+
+    clength = len(contacts)
+    cx = contacts["X"].to_numpy()
+    cy = contacts["Y"].to_numpy()
+    cl = contacts["lsx"].to_numpy(dtype=float)
+    cm = contacts["lsy"].to_numpy(dtype=float)
+    ctextcode = contacts["formation"].to_numpy()
+
+    fth = open(os.path.join(config.output_path, "formation_thicknesses.csv"), "w")
+    fth.write(
+        "X,Y,formation,appar_th,thickness,cl,cm,p1x,p1y,p2x,p2y,dip,type,slope_dip,slope_length,delz,zbase,zcross\n"
+    )
+
+    # np.savetxt(os.path.join(config.tmp_path,'dist.csv'),dist,delimiter = ',')
+    # display("ppp",cx.shape,cy.shape,ox.shape,oy.shape,dip.shape,azimuth.shape,dist.shape)
+    n_est = 0
+    for k in range(0, clength):  # loop through all contact segments
+        r = int((cy[k] - config.bbox[1]) / config.run_flags["interpolation_spacing"])
+        c = int((cx[k] - config.bbox[0]) / config.run_flags["interpolation_spacing"])
+
+        dip_mean = map_data.dip_grid[r, c]
+
+        dx1 = -cm[k] * config.run_flags["thickness_buffer"]
+        dy1 = cl[k] * config.run_flags["thickness_buffer"]
+        dx2 = -dx1
+        dy2 = -dy1
+        p1 = Point((dx1 + cx[k], dy1 + cy[k]))
+        p2 = Point((dx2 + cx[k], dy2 + cy[k]))
+        ddline = LineString((p1, p2))
+        orig = Point((cx[k], cy[k]))
+
+        crossings = np.zeros((1000, 5))
+
+        g = 0
+        for indx, apair in all_sorts.iterrows():  # loop through all basal contacts
+            if ctextcode[k] == apair["code"]:
+                # subset contacts to just those with 'a' code
+                is_contacta = (
+                        contact_lines["UNIT_NAME"] == all_sorts.iloc[g - 1]["code"]
+                )
+                acontacts = contact_lines[is_contacta]
+                i = 0
+                for (
+                        ind,
+                        acontact,
+                ) in (
+                        acontacts.iterrows()
+                ):  # loop through distinct linestrings for upper contact
+                    # if(bboxes_intersect(ddline.bounds,acontact[1].geometry.bounds)):
+                    if not str(acontact.geometry) == "None":
+                        if ddline.intersects(acontact.geometry):
+                            isects = ddline.intersection(acontact.geometry)
+                            if isects.geom_type == "MultiPoint":
+                                for pt in isects:
+                                    if (
+                                            pt.distance(orig)
+                                            < config.run_flags["thickness_buffer"] * 2
+                                    ):
+                                        # print(i,",", pt.x, ",",pt.y,",",apair[1]['code'],",",apair[1]['group'])
+                                        crossings[i, 0] = i
+                                        crossings[i, 1] = int(apair["index"])
+                                        crossings[i, 2] = 0
+                                        crossings[i, 3] = pt.x
+                                        crossings[i, 4] = pt.y
+                                        i = i + 1
+                            else:
+                                if (
+                                        isects.distance(orig)
+                                        < config.run_flags["thickness_buffer"] * 2
+                                ):
+                                    # print(i,",", isects.x,",", isects.y,",",apair[1]['code'],",",apair[1]['group'])
+                                    crossings[i, 0] = i
+                                    crossings[i, 1] = int(apair["index"])
+                                    crossings[i, 2] = 0
+                                    crossings[i, 3] = isects.x
+                                    crossings[i, 4] = isects.y
+                                    i = i + 1
+
+                            if (
+                                    i > 0
+                            ):  # if we found any intersections with base of next higher unit
+                                min_dist = 1e8
+                                # min_pt = 0
+                                for f in range(0, i):  # find closest hit
+                                    this_dist = m2l_utils.ptsdist(
+                                        crossings[f, 3], crossings[f, 4], cx[k], cy[k]
+                                    )
+                                    if this_dist < min_dist:
+                                        min_dist = this_dist
+                                        # min_pt = f
+                                        crossx = crossings[f, 3]
+                                        crossy = crossings[f, 4]
+                                # if not too far, add to output
+                                if (
+                                        min_dist < config.run_flags["max_thickness_allowed"]
+                                        and min_dist > 0
+                                ):
+                                    locations = [(cx[k], cy[k])]
+                                    zbase = float(
+                                        m2l_utils.value_from_dtm_dtb(
+                                            dtm, "", "", False, locations
+                                        )
+                                    )
+                                    locations = [(crossx, crossy)]
+                                    zcross = float(
+                                        m2l_utils.value_from_dtm_dtb(
+                                            dtm, "", "", False, locations
+                                        )
+                                    )
+                                    delz = fabs(zcross - zbase)
+                                    slope_dip = degrees(atan(delz / min_dist))
+                                    slope_length = sqrt(
+                                        (min_dist * min_dist) + (delz * delz)
+                                    )
+                                    if slope_dip < dip_mean and zbase > zcross:
+                                        surf_dip = dip_mean - slope_dip
+                                    elif slope_dip < dip_mean and zbase < zcross:
+                                        surf_dip = dip_mean + slope_dip
+                                    elif slope_dip > dip_mean and zbase > zcross:
+                                        surf_dip = slope_dip - dip_mean
+                                    else:
+                                        surf_dip = 180 - (dip_mean + slope_dip)
+
+                                    true_thick = slope_length * sin(radians(surf_dip))
+                                    if (
+                                            not isnan(true_thick)
+                                            and true_thick > 0
+                                            and true_thick
+                                            < config.run_flags["max_thickness_allowed"]
+                                    ):
+                                        ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
+                                            cx[k],
+                                            cy[k],
+                                            ctextcode[k],
+                                            min_dist,
+                                            int(true_thick),
+                                            cl[k],
+                                            cm[k],
+                                            p1.x,
+                                            p1.y,
+                                            p2.x,
+                                            p2.y,
+                                            dip_mean,
+                                            "full",
+                                            slope_dip,
+                                            slope_length,
+                                            delz,
+                                            zbase,
+                                            zcross,
+                                        )
+                                        # ostr = str(cx[k])+','+str(cy[k])+','+ctextcode[k]+','+str(int(true_thick))+\
+                                        #    ','+str(cl[k])+','+str(cm[k])+','+str(lm)+','+str(mm)+','+str(nm)+','+\
+                                        #    str(p1.x)+','+str(p1.y)+','+str(p2.x)+','+str(p2.y)+','+str(dip_mean)+'\n'
+                                        fth.write(ostr)
+                                        n_est = n_est + 1
+
+            g = g + 1
+    if config.verbose_level != VerboseLevel.NONE:
+        print(
+            n_est,
+            "thickness estimates saved as",
+            os.path.join(config.output_path, "formation_thicknesses.csv"),
+        )
+
+
+@beartype.beartype
+def calc_min_thickness_with_grid(config: Config, map_data: MapData):
+    dtm = map_data.get_map_data(Datatype.DTM).open()
+    contact_points_file = os.path.join(config.tmp_path, "raw_contacts.csv")
+    # load basal contacts as geopandas dataframe
+    contact_lines = gpd.read_file(
+        os.path.join(config.tmp_path, "basal_contacts.shp.zip")
+    )
+    all_sorts = pd.read_csv(os.path.join(config.tmp_path, "all_sorts.csv"))
+    contacts = pd.read_csv(contact_points_file)
+
+    sum_thick = pd.read_csv(
+        os.path.join(config.output_path, "formation_thicknesses.csv")
+    )
+    found_codes = sum_thick["formation"].unique()
+    if config.verbose_level != VerboseLevel.NONE:
+        print(found_codes, "already processed")
+    clength = len(contacts)
+    cx = contacts["X"].to_numpy()
+    cy = contacts["Y"].to_numpy()
+    cl = contacts["lsx"].to_numpy(dtype=float)
+    cm = contacts["lsy"].to_numpy(dtype=float)
+    ctextcode = contacts["formation"].to_numpy()
+
+    fth = open(os.path.join(config.output_path, "formation_thicknesses.csv"), "a+")
+    # fth.write('X,Y,formation,appar_th,thickness,cl,cm,p1x,p1y,p2x,p2y,dip\n')
+
+    # np.savetxt(os.path.join(config.tmp_path,'dist.csv'),dist,delimiter = ',')
+    # display("ppp",cx.shape,cy.shape,ox.shape,oy.shape,dip.shape,azimuth.shape,dist.shape)
+    n_est = 0
+    for k in range(0, clength):  # loop through all contact segments
+        if not (ctextcode[k] in found_codes):
+            # print(ctextcode[k])
+            r = int(
+                (cy[k] - config.bbox[1]) / config.run_flags["interpolation_spacing"]
+            )
+            c = int(
+                (cx[k] - config.bbox[0]) / config.run_flags["interpolation_spacing"]
+            )
+
+            dip_mean = map_data.dip_grid[r, c]
+
+            dx1 = -cm[k] * config.run_flags["thickness_buffer"]
+            dy1 = cl[k] * config.run_flags["thickness_buffer"]
+            dx2 = -dx1
+            dy2 = -dy1
+            p1 = Point((dx1 + cx[k], dy1 + cy[k]))
+            p2 = Point((dx2 + cx[k], dy2 + cy[k]))
+            ddline = LineString((p1, p2))
+            orig = Point((cx[k], cy[k]))
+
+            crossings = np.zeros((1000, 5))
+
+            g = 0
+            for indx, apair in all_sorts.iterrows():  # loop through all basal contacts
+                if ctextcode[k] == apair["code"]:
+                    # subset contacts to just those with 'a' code
+                    is_contacta = (
+                            contact_lines["UNIT_NAME"] != all_sorts.iloc[g - 1]["code"]
+                    )
+                    acontacts = contact_lines[is_contacta]
+                    i = 0
+                    for (
+                            ind,
+                            acontact,
+                    ) in (
+                            acontacts.iterrows()
+                    ):  # loop through distinct linestrings for upper contact
+                        # if(bboxes_intersect(ddline.bounds,acontact[1].geometry.bounds)):
+
+                        if not str(acontact.geometry) == "None":
+                            if ddline.intersects(acontact.geometry):
+                                isects = ddline.intersection(acontact.geometry)
+                                if isects.geom_type == "MultiPoint":
+                                    for pt in isects.geoms:
+                                        if (
+                                                pt.distance(orig)
+                                                < config.run_flags["thickness_buffer"] * 2
+                                        ):
+                                            # print(i,",", pt.x, ",",pt.y,",",apair[1]['code'],",",apair[1]['group'])
+                                            crossings[i, 0] = i
+                                            crossings[i, 1] = int(apair["index"])
+                                            crossings[i, 2] = 0
+                                            crossings[i, 3] = pt.x
+                                            crossings[i, 4] = pt.y
+                                            i = i + 1
+                                else:
+                                    if not isects.geom_type == "GeometryCollection":
+                                        if (
+                                                isects.distance(orig)
+                                                < config.run_flags["thickness_buffer"] * 2
+                                        ):
+                                            # print(i,",", isects.x,",", isects.y,",",apair[1]['code'],",",apair[1]['group'])
+                                            crossings[i, 0] = i
+                                            crossings[i, 1] = int(apair["index"])
+                                            crossings[i, 2] = 0
+                                            crossings[i, 3] = isects.x
+                                            crossings[i, 4] = isects.y
+                                            i = i + 1
+
+                                if (
+                                        i > 0
+                                ):  # if we found any intersections with base of next higher unit
+                                    min_dist = 1e8
+                                    # min_pt = 0
+                                    for f in range(0, i):  # find closest hit
+                                        this_dist = m2l_utils.ptsdist(
+                                            crossings[f, 3],
+                                            crossings[f, 4],
+                                            cx[k],
+                                            cy[k],
+                                        )
+                                        if this_dist < min_dist:
+                                            min_dist = this_dist
+                                            # min_pt = f
+                                            crossx = crossings[f, 3]
+                                            crossy = crossings[f, 4]
+                                    # if not too far, add to output
+                                    if (
+                                            min_dist
+                                            < config.run_flags["max_thickness_allowed"]
+                                            and min_dist > 1
+                                    ):
+                                        locations = [(cx[k], cy[k])]
+                                        zbase = float(
+                                            m2l_utils.value_from_dtm_dtb(
+                                                dtm, "", "", False, locations
+                                            )
+                                        )
+                                        locations = [(crossx, crossy)]
+                                        zcross = float(
+                                            m2l_utils.value_from_dtm_dtb(
+                                                dtm, "", "", False, locations
+                                            )
+                                        )
+                                        delz = fabs(zcross - zbase)
+                                        slope_dip = degrees(atan(delz / min_dist))
+                                        slope_length = sqrt(
+                                            (min_dist * min_dist) + (delz * delz)
+                                        )
+                                        if slope_dip < dip_mean and zbase > zcross:
+                                            surf_dip = dip_mean - slope_dip
+                                        elif slope_dip < dip_mean and zbase < zcross:
+                                            surf_dip = dip_mean + slope_dip
+                                        elif slope_dip > dip_mean and zbase > zcross:
+                                            surf_dip = slope_dip - dip_mean
+                                        else:
+                                            surf_dip = 180 - (dip_mean + slope_dip)
+
+                                        true_thick = slope_length * sin(
+                                            radians(surf_dip)
+                                        )
+                                        if (
+                                                not isnan(true_thick)
+                                                and true_thick > 0
+                                                and true_thick
+                                                < config.run_flags["max_thickness_allowed"]
+                                        ):
+                                            ostr = "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}\n".format(
+                                                cx[k],
+                                                cy[k],
+                                                ctextcode[k],
+                                                min_dist,
+                                                int(true_thick),
+                                                cl[k],
+                                                cm[k],
+                                                p1.x,
+                                                p1.y,
+                                                p2.x,
+                                                p2.y,
+                                                dip_mean,
+                                                "min",
+                                                slope_dip,
+                                                slope_length,
+                                                delz,
+                                                zbase,
+                                                zcross,
+                                            )
+                                            # ostr = str(cx[k])+','+str(cy[k])+','+ctextcode[k]+','+str(int(true_thick))+\
+                                            #    ','+str(cl[k])+','+str(cm[k])+','+str(lm)+','+str(mm)+','+str(nm)+','+\
+                                            #    str(p1.x)+','+str(p1.y)+','+str(p2.x)+','+str(p2.y)+','+str(dip_mean)+'\n'
+                                            fth.write(ostr)
+                                            n_est = n_est + 1
+
+            g = g + 1
+    if config.verbose_level != VerboseLevel.NONE:
+        print(
+            n_est,
+            "min thickness estimates appended to",
+            os.path.join(config.output_path, "formation_thicknesses.csv"),
+        )
+    fth.close()
+
+
+####################################
+# Normalise thickness for each estimate to median for that formation
+#
+# normalise_thickness(output_path)
+# Args:
+# output_path path to m2l output directory
+#
+# Normalises previously calculated formation thickness by dviding by median value for that formation
+####################################
+def normalise_thickness(output_path):
+    thickness = pd.read_csv(
+        os.path.join(output_path, "formation_thicknesses.csv"), sep=","
+    )
+
+    codes = thickness.formation.unique()
+    f = open(os.path.join(output_path, "formation_thicknesses_norm.csv"), "w")
+    f.write("x,y,formation,app_th,thickness,norm_th\n")
+    fs = open(os.path.join(output_path, "formation_summary_thicknesses.csv"), "w")
+    fs.write("formation,thickness median,thickness std,method\n")
+    for code in codes:
+        is_code = thickness.formation.str.contains(code, regex=False)
+        all_thick = thickness[is_code]
+        all_thick2 = all_thick[all_thick["thickness"] != 0]
+        thicknesses = np.asarray(all_thick2.loc[:, "thickness"], dtype=float)
+
+        if len(all_thick2) > 2:
+            med = np.median(thicknesses)
+            std = np.std(thicknesses)
+            # print(code, med, std)
+            ostr = "{},{},{},{}\n".format(code, med, std, all_thick2.iloc[0]["type"])
+            # ostr = str(code)+","+str(all_thick2.loc[:,"thickness"].median())+","+str(all_thick2.loc[:,"thickness"].std())+"\n"
+            fs.write(ostr)
+
+            thick = all_thick2.to_numpy()
+
+            for i in range(len(thick)):
+                if med > 0:
+                    ostr = "{},{},{},{},{},{}\n".format(
+                        thick[i, 0],
+                        thick[i, 1],
+                        thick[i, 2],
+                        thick[i, 3],
+                        thick[i, 4],
+                        thicknesses[i] / med,
+                    )
+                    # ostr = str(thick[i,0])+","+str(thick[i,1])+","+str(thick[i,2])+","+str(thick[i,3])+","+str(thick[i,3]/med)+"\n"
+                    f.write(ostr)
+    f.close()
+    fs.close()

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -53,15 +53,15 @@ def normal_vector_to_dipdirection_dip(nx, ny, nz):
     """
 
     # Calculate the dip direction in degrees, ranging from 0 to 360
-    dipdir = degrees(atan2(nx, ny)) % 360
+    dipdir = numpy.degrees(numpy.arctan2(nx, ny)) % 360
 
     # Calculate the dip angle in degrees, ranging from 0 to 90
-    dip = 90 - degrees(asin(nz))
+    dip = 90 - numpy.degrees(numpy.arcsin(nz))
 
     # If the dip angle is greater than 90 degrees, adjust the dip and dip direction
-    if dip > 90:
-        dip = 180 - dip
-        dipdir = dipdir + 180
+    mask = dip > 90
+    dip[mask] = 180 - dip[mask]
+    dipdir[mask] = (dipdir[mask] + 180) % 360
 
     # Ensure the dip direction is within the range of 0 to 360 degrees
     dipdir = dipdir % 360

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -1,0 +1,13 @@
+import numpy
+
+
+def strike_dip_vector(strike, dip):
+    # this code is from LoopStructural
+    vec = numpy.zeros((len(strike), 3))
+    s_r = numpy.deg2rad(strike)
+    d_r = numpy.deg2rad(dip)
+    vec[:, 0] = numpy.sin(d_r) * numpy.cos(s_r)
+    vec[:, 1] = -numpy.sin(d_r) * numpy.sin(s_r)
+    vec[:, 2] = numpy.cos(d_r)
+    vec /= numpy.linalg.norm(vec, axis=1)[:, None]
+    return vec

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -1,6 +1,41 @@
 import numpy
-from math import radians, degrees, atan2, asin
 from shapely.geometry import Point
+import beartype
+
+
+@beartype.beartype
+def setup_grid(bounding_box: dict):
+    """
+    Setup the grid for interpolation
+
+    Args:
+        bounding_box
+
+    Returns:
+        xi, yi (numpy.ndarray, numpy.ndarray): The x and y coordinates of the grid points.
+    """
+    # Define the desired cell size
+    cell_size = 0.01 * (bounding_box["maxx"] - bounding_box["minx"])
+
+    # Calculate the grid resolution
+    grid_resolution = round((bounding_box["maxx"] - bounding_box["minx"]) / cell_size)
+
+    # Generate the grid
+    x = numpy.linspace(
+        bounding_box["minx"],
+        bounding_box["maxx"],
+        grid_resolution,
+    )
+    y = numpy.linspace(
+        bounding_box["miny"],
+        bounding_box["maxy"],
+        grid_resolution,
+    )
+    xi, yi = numpy.meshgrid(x, y)
+    xi = xi.flatten()
+    yi = yi.flatten()
+
+    return xi, yi
 
 
 def strike_dip_vector(strike, dip):
@@ -42,9 +77,9 @@ def normal_vector_to_dipdirection_dip(nx, ny, nz):
     This function calculates the dip and dip direction from a normal vector.
 
     Parameters:
-    nx (float): The x-component of the normal vector.
-    ny (float): The y-component of the normal vector.
-    nz (float): The z-component of the normal vector.
+    nx: The x-component of the normal vector.
+    ny: The y-component of the normal vector.
+    nz: The z-component of the normal vector.
 
     Returns:
     dip (float): The dip angle in degrees, ranging from 0 to 90.

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -1,13 +1,68 @@
 import numpy
+from math import radians, degrees, atan2, asin
 
 
 def strike_dip_vector(strike, dip):
-    # this code is from LoopStructural
+    """
+    This function calculates the strike-dip vector from the given strike and dip angles.
+
+    Parameters:
+    strike (float or array-like): The strike angle(s) in degrees. Can be a single value or an array of values.
+    dip (float or array-like): The dip angle(s) in degrees. Can be a single value or an array of values.
+
+    Returns:
+    vec (numpy.ndarray): The calculated strike-dip vector(s). Each row corresponds to a vector,
+    and the columns correspond to the x, y, and z components of the vector.
+
+    Note:
+    This code is adapted from LoopStructural.
+    """
+
+    # Initialize a zero vector with the same length as the input strike and dip angles
     vec = numpy.zeros((len(strike), 3))
+
+    # Convert the strike and dip angles from degrees to radians
     s_r = numpy.deg2rad(strike)
     d_r = numpy.deg2rad(dip)
+
+    # Calculate the x, y, and z components of the strike-dip vector
     vec[:, 0] = numpy.sin(d_r) * numpy.cos(s_r)
     vec[:, 1] = -numpy.sin(d_r) * numpy.sin(s_r)
     vec[:, 2] = numpy.cos(d_r)
+
+    # Normalize the strike-dip vector
     vec /= numpy.linalg.norm(vec, axis=1)[:, None]
+
     return vec
+
+
+def normal_vector_to_dipdirection_dip(nx, ny, nz):
+    """
+    This function calculates the dip and dip direction from a normal vector.
+
+    Parameters:
+    nx (float): The x-component of the normal vector.
+    ny (float): The y-component of the normal vector.
+    nz (float): The z-component of the normal vector.
+
+    Returns:
+    dip (float): The dip angle in degrees, ranging from 0 to 90.
+    dipdir (float): The dip direction in degrees, ranging from 0 to 360.
+
+    """
+
+    # Calculate the dip direction in degrees, ranging from 0 to 360
+    dipdir = degrees(atan2(nx, ny)) % 360
+
+    # Calculate the dip angle in degrees, ranging from 0 to 90
+    dip = 90 - degrees(asin(nz))
+
+    # If the dip angle is greater than 90 degrees, adjust the dip and dip direction
+    if dip > 90:
+        dip = 180 - dip
+        dipdir = dipdir + 180
+
+    # Ensure the dip direction is within the range of 0 to 360 degrees
+    dipdir = dipdir % 360
+
+    return dip, dipdir

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -1,5 +1,6 @@
 import numpy
 from math import radians, degrees, atan2, asin
+from shapely.geometry import Point
 
 
 def strike_dip_vector(strike, dip):
@@ -66,3 +67,11 @@ def normal_vector_to_dipdirection_dip(nx, ny, nz):
     dipdir = dipdir % 360
 
     return dip, dipdir
+
+
+def create_points(xy):
+    points = []
+    for x, y in xy:
+        point = Point(x, y)
+        points.append(point)
+    return points


### PR DESCRIPTION
New `ThicknessCalculatorBeta` that calculates thickness using interpolated structural data. Currently, the thickness calculator only returns the median thickness and its standard deviation.

**Changes Made:**

    - Added ThicknessCalculatorBeta
    - Added interpolator.py to handle interpolation operations. Two interpolators are added: NormalVectorsInterpolator and DipDirectionInterpolator
    - Added utils.py which has helper functions that are useful for the thickness calculator and the interpolators
    - Modified MapData to store sampled contacts to be able to access them in the thickness calculator
    - Modified Project to be able to access sampled structural data to use in thickness calculations
   
**Notes for Reviewers:**

  - Are the two interpolators really needed in the future, or should we use only one?
  - Should we use different names for the columns' thickness, e.g., BetaThickness, so each thickness value refers to the name of the calculator that computed it? 

**Future changes:** 

   - Once I write the code for storing sampled data, I will add the option of making a thickness map



