### PR TITLE
Fix docs config so that examples tab appears

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -27,12 +27,9 @@ RUN conda install -c conda-forge --file ./docs/requirements.txt -y
 
 RUN pip install .
 
-# RUN pip install lavavu-osmesa==1.8.45 
-ENV LD_LIBRARY_PATH=/opt/conda/lib/python3.10/site-packages/lavavu_osmesa.libs
-
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-# ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/tini", "--"]
 
 WORKDIR /

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -27,9 +27,4 @@ RUN conda install -c conda-forge --file ./docs/requirements.txt -y
 
 RUN pip install .
 
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
-
 WORKDIR /

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,6 @@ autosummary_mock_imports = ["LoopStructural.interpolators._cython"]
 # Sphinx gallery examples
 
 
-
 # from LoopStructural.visualisation.sphinx_scraper import Scraper as LoopScraper
 from sphinx_gallery.sorting import ExampleTitleSortKey
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,19 +105,17 @@ autosummary_mock_imports = ["LoopStructural.interpolators._cython"]
 # Sphinx gallery examples
 
 
-try:
-    from LoopStructural.visualisation.sphinx_scraper import Scraper as LoopScraper
-    from sphinx_gallery.sorting import ExampleTitleSortKey
 
-    sphinx_gallery_conf = {
-        "examples_dirs": ["../examples/"],
-        "gallery_dirs": ["_auto_examples/"],  # path to where to save gallery generated output
-        "image_scrapers": ("matplotlib", LoopScraper()),
-        "within_subsection_order": ExampleTitleSortKey,
-        "reference_url": {"LoopStructural": None},
-    }
-except ImportError:
-    pass
+# from LoopStructural.visualisation.sphinx_scraper import Scraper as LoopScraper
+from sphinx_gallery.sorting import ExampleTitleSortKey
+
+sphinx_gallery_conf = {
+    "examples_dirs": ["../examples/"],
+    "gallery_dirs": ["_auto_examples/"],  # path to where to save gallery generated output
+    "image_scrapers": ("matplotlib"),
+    "within_subsection_order": ExampleTitleSortKey,
+    "reference_url": {"LoopStructural": None},
+}
 
 # def setup(app):
 #     app.add_stylesheet('custom.css')


### PR DESCRIPTION
It was noted that the "examples" tab was not in the documentation artifact uploaded by the documentation-test action, and therefore not in the deployed documentation pages. 

Taking into consideration the current state of the documentation, we don't really need a 3D scrapper in the sphinx config, so I suggest removing it for now, which seems to resolve the issue, as well as removing the ```try``` statement to make sure the config is properly set up. Once we need it in future releases, we'll need to deal with installing Lavavu in the Dockerfile. 

Please check the artifact uploaded in **https://github.com/Loop3D/map2loop/commit/e8b1ada0345cfebef114be555e770fd594155b16**, which contains the examples tab again. 

