### PR TITLE
fix: pin numpy version

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,4 +1,5 @@
 geopandas
+numpy==1.26.4
 shapely
 networkx
 owslib

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,5 @@
 geopandas
-numpy==1.26.4
+numpy<=1.26.4
 shapely
 networkx
 owslib

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,4 @@
 geopandas
-numpy<2.0.0
 shapely
 networkx
 owslib

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,5 @@
 geopandas
-numpy<=1.26.4
+numpy<2.0.0
 shapely
 networkx
 owslib

--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -501,8 +501,8 @@ class MapData:
         
         # For gdal debugging use exceptions
         gdal.UseExceptions()
-        bb_ll = tuple(self.bounding_box_polygon.to_crs("EPSG:4326").geometry.total_bounds)
-    
+        bb_ll = tuple(float(coord) for coord in self.bounding_box_polygon.to_crs("EPSG:4326").geometry.total_bounds)
+
         if filename.lower() == "aus" or filename.lower() == "au":
 
             url = "http://services.ga.gov.au/gis/services/DEM_SRTM_1Second_over_Bathymetry_Topography/MapServer/WCSServer?"
@@ -511,6 +511,7 @@ class MapData:
             coverage = wcs.getCoverage(
                 identifier="1", bbox=bb_ll, format="GeoTIFF", crs=4326, width=2048, height=2048
             )
+            
             # This is stupid that gdal cannot read a byte stream and has to have a
             # file on the local system to open or otherwise create a gdal file
             # from scratch with Create


### PR DESCRIPTION
## Description

`numpy`'s new version [2.0.0](https://pypi.org/project/numpy/2.0.0/#history) is creating a conflict with `owslib`, which is breaking the GitHub Actions in `map2loop`. 

This PR is to pin `numpy` version to the last working version - 1.26.4.
