### PR TITLE
fix: issue 122

### DIFF
--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -457,7 +457,7 @@ class StructuralPoint(ThicknessCalculator):
         
         # remove nans from sampled structures 
         # this happens when there are strati measurements within intrusions. If intrusions are removed from the geology map, unit_name will then return a nan
-        print('skipping row(s) ', sampled_structures[sampled_structures['unit_name'].isnull()].index.to_numpy(), 'in sampled structures dataset, as they do not spatially coincide with a valid geology polygon \n') 
+        print(f"skipping row(s) {sampled_structures[sampled_structures['unit_name'].isnull()].index.to_numpy()} in sampled structures dataset, as they do not spatially coincide with a valid geology polygon \n")
         sampled_structures = sampled_structures.dropna(subset=['unit_name'])
                 
         
@@ -491,7 +491,7 @@ class StructuralPoint(ThicknessCalculator):
             # check if litho_in is in geology
             # for a special case when the litho_in is not in the geology
             if len(geology[geology['UNITNAME'] == litho_in]) == 0: 
-                print('There are structural measurements in unit - ', litho_in,  ' - that is not in the geology shapefile. Skipping this structural measurement')
+                print(f"There are structural measurements in unit - {litho_in} - that are not in the geology shapefile. Skipping this structural measurement")
                 continue
             else:          
                 # make a subset of the geology polygon & find neighbour units

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -454,7 +454,13 @@ class StructuralPoint(ThicknessCalculator):
         )
         # add unitname to the sampled structures
         sampled_structures['unit_name'] = geopandas.sjoin(sampled_structures, geology)['UNITNAME']
-
+        
+        # remove nans from sampled structures 
+        # this happens when there are strati measurements within intrusions. If intrusions are removed from the geology map, unit_name will then return a nan
+        print('skipping row(s) ', sampled_structures[sampled_structures['unit_name'].isnull()].index.to_numpy(), 'in sampled structures dataset, as they do not spatially coincide with a valid geology polygon \n') 
+        sampled_structures = sampled_structures.dropna(subset=['unit_name'])
+                
+        
         # rebuild basal contacts lines based on sampled dataset
         sampled_basal_contacts = rebuild_sampled_basal_contacts(
             basal_contacts, map_data.sampled_contacts
@@ -482,8 +488,15 @@ class StructuralPoint(ThicknessCalculator):
             # find bounding box of the lithology
             bbox_poly = geology[geology['UNITNAME'] == litho_in][['minx', 'miny', 'maxx', 'maxy']]
 
-            # make a subset of the geology polygon & find neighbour units
-            GEO_SUB = geology[geology['UNITNAME'] == litho_in]['geometry'].values[0]
+            # check if litho_in is in geology
+            # for a special case when the litho_in is not in the geology
+            if len(geology[geology['UNITNAME'] == litho_in]) == 0: 
+                print('There are structural measurements in unit - ', litho_in,  ' - that is not in the geology shapefile. Skipping this structural measurement')
+                continue
+            else:          
+                # make a subset of the geology polygon & find neighbour units
+                GEO_SUB = geology[geology['UNITNAME'] == litho_in]['geometry'].values[0]
+
             neighbor_list = list(
                 basal_contacts[GEO_SUB.intersects(basal_contacts.geometry)]['basal_unit']
             )


### PR DESCRIPTION
## Description

Intrusives are usually removed from the geology file (if the config file allows). 
if a strati measurement falls into an intrusive, it cannot be used to measure thickness. 
This fix removes measurements that fall into empty geology. 

Also added check to skip units that are not in the geology map. 

Fixes #122

## Type of change

- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test improvement

## How Has This Been Tested?

Please describe any tests that you ran to verify your changes. 
Provide branch name so we can reproduce.

Tested with code given in issue #122 & branch fix/strati_column_extra_units

## Checklist:

- [x] This branch is up-to-date with master
- [x] All gh-action checks are passing
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My tests run with pytest from the map2loop folder
- [x] New and existing tests pass locally with my changes

## Checklist continued (if PR includes changes to documentation) 
- [ ] I have built the documentation locally with make.bat
- [ ] I have built this documentation in docker, following the docker configuration in map2loop/docs
- [ ] I have checked my spelling and grammar