### PR TITLE
feat: remove option for legacy hson files

### DIFF
--- a/map2loop/config.py
+++ b/map2loop/config.py
@@ -138,14 +138,13 @@ class Config:
 
     @beartype.beartype
     def update_from_file(
-        self, filename: Union[pathlib.Path, str], legacy_format: bool = False, lower: bool = False
+        self, filename: Union[pathlib.Path, str],  lower: bool = False
     ):
         """
         Update the config dictionary from the provided json filename or url
 
         Args:
             filename (Union[pathlib.Path, str]): Filename or URL of the JSON config file
-            legacy_format (bool, optional): Whether the JSON is an old version. Defaults to False.
             lower (bool, optional): convert keys to lowercase. Defaults to False.
         """
         func = self.update_from_dictionary
@@ -207,7 +206,5 @@ class Config:
                 err_string += "Please check the file is accessible online and then\n"
             else:
                 err_string += "Please check the file exists and is accessible then\n"
-            if not legacy_format:
-                err_string += "Also check if this is a legacy config file and add clut_file_legacy=True to the Project function\n"
             err_string += "Check the contents for mismatched quotes or brackets!"
             raise Exception(err_string)

--- a/map2loop/config.py
+++ b/map2loop/config.py
@@ -135,65 +135,6 @@ class Config:
         if len(dictionary):
             logger.warning(f"Unused keys from config format {list(dictionary.keys())}")
 
-    @beartype.beartype
-    def update_from_legacy_file(self, file_map: dict, lower: bool = False):
-        """
-        Update the config dictionary from the provided old version dictionary
-
-        Args:
-            file_map (dict): The old version dictionary to update from
-        """
-
-        code_mapping = {
-            "otype": (self.structure_config, "orientation_type"),
-            "dd": (self.structure_config, "dipdir_column"),
-            "d": (self.structure_config, "dip_column"),
-            "sf": (self.structure_config, "description_column"),
-            "bedding": (self.structure_config, "bedding_text"),
-            "bo": (self.structure_config, "overturned_column"),
-            "btype": (self.structure_config, "overturned_text"),
-            "gi": (self.structure_config, "objectid_column"),
-            "c": (self.geology_config, "unitname_column"),
-            "u": (self.geology_config, "alt_unitname_column"),
-            "g": (self.geology_config, "group_column"),
-            "g2": (self.geology_config, "supergroup_column"),
-            "ds": (self.geology_config, "description_column"),
-            "min": (self.geology_config, "minage_column"),
-            "max": (self.geology_config, "maxage_column"),
-            "r1": (self.geology_config, "rocktype_column"),
-            "r2": (self.geology_config, "alt_rocktype_column"),
-            "sill": (self.geology_config, "sill_text"),
-            "intrusive": (self.geology_config, "intrusive_text"),
-            "volcanic": (self.geology_config, "volcanic_text"),
-            "f": (self.fault_config, "structtype_column"),
-            "fault": (self.fault_config, "fault_text"),
-            "fdipnull": (self.fault_config, "dip_null_value"),
-            "fdipdip_flag": (self.fault_config, "dipdir_flag"),
-            "fdipdir": (self.fault_config, "dipdir_column"),
-            "fdip": (self.fault_config, "dip_column"),
-            "fdipest": (self.fault_config, "dipestimate_column"),
-            "fdipest_vals": (self.fault_config, "dipestimate_text"),
-            "n": (self.fault_config, "name_column"),
-            "ff": (self.fold_config, "structtype_column"),
-            "fold": (self.fold_config, "fold_text"),
-            "t": (self.fold_config, "description_column"),
-            "syn": (self.fold_config, "synform_text"),
-        }
-        for code in code_mapping:
-            if code in file_map:
-                if lower is True:
-                    file_map[code] = str(file_map[code]).lower()
-                code_mapping[code][0][code_mapping[code][1]] = file_map[code]
-                file_map.pop(code)
-
-        if "o" in file_map:
-            self.structure_config["objectid_column"] = file_map["o"]
-            self.fault_config["objectid_column"] = file_map["o"]
-            self.fold_config["objectid_column"] = file_map["o"]
-            file_map.pop("o")
-
-        if len(file_map) > 0:
-            logger.warning(f"Unused keys from legacy format {list(file_map.keys())}")
 
     @beartype.beartype
     def update_from_file(
@@ -207,10 +148,7 @@ class Config:
             legacy_format (bool, optional): Whether the JSON is an old version. Defaults to False.
             lower (bool, optional): convert keys to lowercase. Defaults to False.
         """
-        if legacy_format:
-            func = self.update_from_legacy_file
-        else:
-            func = self.update_from_dictionary
+        func = self.update_from_dictionary
 
         try:
             filename = str(filename)

--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -255,7 +255,7 @@ class MapData:
 
     @beartype.beartype
     def set_config_filename(
-        self, filename: Union[pathlib.Path, str], legacy_format: bool = False, lower: bool = False
+        self, filename: Union[pathlib.Path, str],  lower: bool = False
     ):
         """
         Set the config filename and update the config structure
@@ -263,12 +263,12 @@ class MapData:
         Args:
             filename (str):
                 The filename of the config file
-            legacy_format (bool, optional):
-                Whether the file is in m2lv2 form. Defaults to False.
+            lower (bool, optional):
+                Flag to convert the config file to lowercase. Defaults to False.
         """
         logger.info('Setting config filename to {filename}')
 
-        self.config.update_from_file(filename, legacy_format=legacy_format, lower=lower)
+        self.config.update_from_file(filename,  lower=lower)
         logger.info(f"Config is: {self.config.to_dict()}")
 
     def get_config_filename(self):
@@ -399,7 +399,7 @@ class MapData:
 
             else:
                 self.set_config_filename(
-                    AustraliaStateUrls.aus_config_urls[state], legacy_format=False, lower=lower
+                    AustraliaStateUrls.aus_config_urls[state],  lower=lower
                 )
                 self.set_colour_filename(AustraliaStateUrls.aus_clut_urls[state])
         else:

--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -269,7 +269,7 @@ class MapData:
                 Whether the file is in m2lv2 form. Defaults to False.
         """
         logger.info('Setting config filename to {filename}')
-        self.config_filename = filename
+
         self.config.update_from_file(filename, legacy_format=legacy_format, lower=lower)
         logger.info(f"Config is: {self.config.to_dict()}")
 

--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -267,8 +267,9 @@ class MapData:
                 Flag to convert the config file to lowercase. Defaults to False.
         """
         logger.info('Setting config filename to {filename}')
-
+        
         self.config.update_from_file(filename,  lower=lower)
+        
         logger.info(f"Config is: {self.config.to_dict()}")
 
     def get_config_filename(self):

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -70,7 +70,6 @@ class Project(object):
         config_filename: Union[pathlib.Path, str] = "",
         config_dictionary: dict = {},
         clut_filename: Union[pathlib.Path, str] = "",
-        # clut_file_legacy: bool = False,
         save_pre_checked_map_data: bool = False,
         loop_project_filename: str = "",
         overwrite_loopprojectfile: bool = False,
@@ -145,11 +144,7 @@ class Project(object):
         self.fold_samples = pandas.DataFrame(columns=["ID", "X", "Y", "Z", "featureId"])
         self.geology_samples = pandas.DataFrame(columns=["ID", "X", "Y", "Z", "featureId"])
 
-        # check if user is using a config file or dictionary, if file, break the project.
-        if config_filename != "":
-            logger.error("Config legacy files have been deprecated in v3.2. Please use a dictionary instead.")
-            raise ValueError("Config legacy files have been deprecated in v3.2. Please use a config dictionary instead. You can use the utils function update_from_legacy_file")
-
+        
         # Check for alternate config filenames in kwargs
         if "metadata_filename" in kwargs and config_filename == "":
             config_filename = kwargs["metadata_filename"]
@@ -207,11 +202,17 @@ class Project(object):
         if fault_orientation_filename != "":
             self.map_data.set_filename(Datatype.FAULT_ORIENTATION, fault_orientation_filename)
 
+        if config_filename != "":
+        
+
+            self.map_data.set_config_filename(config_filename)
+
+        if config_dictionary != {}:
+            self.map_data.config.update_from_dictionary(config_dictionary)
         if clut_filename != "":
             self.map_data.set_colour_filename(clut_filename)
             
-        #set config dict
-        self.map_data.config.update_from_dictionary(config_dictionary)
+
         
         # Load all data (both shape and raster)
         self.map_data.load_all_map_data()

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -148,7 +148,7 @@ class Project(object):
         # check if user is using a config file or dictionary, if file, break the project.
         if config_filename != "":
             logger.error("Config legacy files have been deprecated in v3.2. Please use a dictionary instead.")
-            raise ValueError("Config legacy files have been deprecated in v3.2. Please use a dictionary instead.You can use the utils function update_from_legacy_file")
+            raise ValueError("Config legacy files have been deprecated in v3.2. Please use a config dictionary instead. You can use the utils function update_from_legacy_file")
 
         # Check for alternate config filenames in kwargs
         if "metadata_filename" in kwargs and config_filename == "":

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -70,7 +70,7 @@ class Project(object):
         config_filename: Union[pathlib.Path, str] = "",
         config_dictionary: dict = {},
         clut_filename: Union[pathlib.Path, str] = "",
-        clut_file_legacy: bool = False,
+        # clut_file_legacy: bool = False,
         save_pre_checked_map_data: bool = False,
         loop_project_filename: str = "",
         overwrite_loopprojectfile: bool = False,
@@ -106,10 +106,8 @@ class Project(object):
                 The filename of the configuration json file to use (if not using config_dictionary). Defaults to "".
             config_dictionary (dict, optional):
                 A dictionary version of the configuration file. Defaults to {}.
-            clut_filename (str, optional):
+            clut_filename (str, deprecated):
                 The filename of the colour look up table to use. Defaults to "".
-            clut_file_legacy (bool, optional):
-                A flag to indicate if the clut file is in the legacy format. Defaults to False.
             save_pre_checked_map_data (bool, optional):
                 A flag to save all map data to file before use. Defaults to False.
             loop_project_filename (str, optional):
@@ -145,6 +143,11 @@ class Project(object):
         self.fault_samples = pandas.DataFrame(columns=["ID", "X", "Y", "Z", "featureId"])
         self.fold_samples = pandas.DataFrame(columns=["ID", "X", "Y", "Z", "featureId"])
         self.geology_samples = pandas.DataFrame(columns=["ID", "X", "Y", "Z", "featureId"])
+
+        # check if user is using a config file or dictionary, if file, break the project.
+        if config_filename != "":
+            logger.error("Config legacy files have been deprecated in v3.2. Please use a dictionary instead.")
+            raise ValueError("Config legacy files have been deprecated in v3.2. Please use a dictionary instead.You can use the utils function update_from_legacy_file")
 
         # Check for alternate config filenames in kwargs
         if "metadata_filename" in kwargs and config_filename == "":
@@ -203,18 +206,12 @@ class Project(object):
         if fault_orientation_filename != "":
             self.map_data.set_filename(Datatype.FAULT_ORIENTATION, fault_orientation_filename)
 
-        if config_filename != "":
-            if clut_file_legacy:
-                logger.warning(
-                    "DEPRECATION: Legacy files are deprecated and their use will be removed in v3.2"
-                )
-
-            self.map_data.set_config_filename(config_filename, legacy_format=clut_file_legacy)
-
-        if config_dictionary != {}:
-            self.map_data.config.update_from_dictionary(config_dictionary)
         if clut_filename != "":
             self.map_data.set_colour_filename(clut_filename)
+            
+        #set config dict
+        self.map_data.config.update_from_dictionary(config_dictionary)
+        
         # Load all data (both shape and raster)
         self.map_data.load_all_map_data()
 

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -105,7 +105,7 @@ class Project(object):
                 The filename of the configuration json file to use (if not using config_dictionary). Defaults to "".
             config_dictionary (dict, optional):
                 A dictionary version of the configuration file. Defaults to {}.
-            clut_filename (str, deprecated):
+            clut_filename (str, optional):
                 The filename of the colour look up table to use. Defaults to "".
             save_pre_checked_map_data (bool, optional):
                 A flag to save all map data to file before use. Defaults to False.
@@ -201,14 +201,13 @@ class Project(object):
             self.map_data.set_filename(Datatype.DTM, dtm_filename)
         if fault_orientation_filename != "":
             self.map_data.set_filename(Datatype.FAULT_ORIENTATION, fault_orientation_filename)
-
+       
         if config_filename != "":
-        
-
             self.map_data.set_config_filename(config_filename)
 
         if config_dictionary != {}:
             self.map_data.config.update_from_dictionary(config_dictionary)
+            
         if clut_filename != "":
             self.map_data.set_colour_filename(clut_filename)
             

--- a/map2loop/sorter.py
+++ b/map2loop/sorter.py
@@ -118,8 +118,8 @@ class SorterUseNetworkX(Sorter):
 
 class SorterUseHint(SorterUseNetworkX):
     def __init__(self):
-        print(
-            "SorterUseHint is deprecated and will be removed in map2loop v3.2. Use SorterUseNetworkX instead"
+        logger.info(
+            "SorterUseHint is deprecated in v3.2. Use SorterUseNetworkX instead"
         )
         super().__init__()
 

--- a/map2loop/utils.py
+++ b/map2loop/utils.py
@@ -5,6 +5,11 @@ import geopandas
 import beartype
 from typing import Union, Optional, Dict
 import pandas
+import re
+import json
+
+from .logging import getLogger
+logger = getLogger(__name__)
 
 
 @beartype.beartype
@@ -401,3 +406,115 @@ def calculate_minimum_fault_length(
 
     # Return the square root of the threshold area as the minimum fault length
     return threshold_area**0.5
+
+
+def preprocess_hjson_to_json(hjson_content):
+    # Remove comments
+    hjson_content = re.sub(r'#.*', '', hjson_content)
+    hjson_content = re.sub(r'//.*', '', hjson_content)
+    # Replace single quotes with double quotes
+    hjson_content = re.sub(r"(?<!\\)'", '"', hjson_content)
+    # Ensure keys are enclosed in double quotes
+    hjson_content = re.sub(r'(?<!")([a-zA-Z0-9_]+)\s*:', r'"\1":', hjson_content)
+    # Fix trailing commas
+    hjson_content = re.sub(r',\s*([\]}])', r'\1', hjson_content)
+    # Remove unnecessary whitespace
+    hjson_content = re.sub(r'\s+', ' ', hjson_content.strip())
+    return hjson_content
+
+@beartype.beartype
+def read_hjson_with_json(file_path: str) -> dict:
+    try:
+        # Read the file
+        with open(file_path, "r", encoding="utf-8") as file:
+            hjson_content = file.read()
+        if not hjson_content.strip():
+            raise ValueError("The HJSON file is empty.")
+        # Preprocess HJSON to JSON
+        preprocessed_content = preprocess_hjson_to_json(hjson_content)
+        # Parse JSON
+        return json.loads(preprocessed_content)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"HJSON file not found: {file_path}") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to decode preprocessed HJSON as JSON: {e}") from e
+    
+    
+def update_from_legacy_file(
+    filename: str,
+    json_save_path: Optional[str] = None,
+    lower: bool = False
+) -> Optional[Dict[str, Dict]]:
+    """
+    Update the config dictionary from the provided old version dictionary
+    Args:
+        file_map (dict): The old version dictionary to update from
+    """
+    # only import config if needed
+    from .config import Config
+    file_map = Config()
+    
+    code_mapping = {
+        "otype": (file_map.structure_config, "orientation_type"),
+        "dd": (file_map.structure_config, "dipdir_column"),
+        "d": (file_map.structure_config, "dip_column"),
+        "sf": (file_map.structure_config, "description_column"),
+        "bedding": (file_map.structure_config, "bedding_text"),
+        "bo": (file_map.structure_config, "overturned_column"),
+        "btype": (file_map.structure_config, "overturned_text"),
+        "gi": (file_map.structure_config, "objectid_column"),
+        "c": (file_map.geology_config, "unitname_column"),
+        "u": (file_map.geology_config, "alt_unitname_column"),
+        "g": (file_map.geology_config, "group_column"),
+        "g2": (file_map.geology_config, "supergroup_column"),
+        "ds": (file_map.geology_config, "description_column"),
+        "min": (file_map.geology_config, "minage_column"),
+        "max": (file_map.geology_config, "maxage_column"),
+        "r1": (file_map.geology_config, "rocktype_column"),
+        "r2": (file_map.geology_config, "alt_rocktype_column"),
+        "sill": (file_map.geology_config, "sill_text"),
+        "intrusive": (file_map.geology_config, "intrusive_text"),
+        "volcanic": (file_map.geology_config, "volcanic_text"),
+        "f": (file_map.fault_config, "structtype_column"),
+        "fault": (file_map.fault_config, "fault_text"),
+        "fdipnull": (file_map.fault_config, "dip_null_value"),
+        "fdipdip_flag": (file_map.fault_config, "dipdir_flag"),
+        "fdipdir": (file_map.fault_config, "dipdir_column"),
+        "fdip": (file_map.fault_config, "dip_column"),
+        "fdipest": (file_map.fault_config, "dipestimate_column"),
+        "fdipest_vals": (file_map.fault_config, "dipestimate_text"),
+        "n": (file_map.fault_config, "name_column"),
+        "ff": (file_map.fold_config, "structtype_column"),
+        "fold": (file_map.fold_config, "fold_text"),
+        "t": (file_map.fold_config, "description_column"),
+        "syn": (file_map.fold_config, "synform_text"),
+    }
+    # try and ready the file:
+    try:
+        parsed_data = read_hjson_with_json(filename)
+    except Exception as e:
+        logger.error(f"Error reading file {filename}: {e}")
+        return
+    #map the keys 
+    file_map = file_map.to_dict()
+    for legacy_key, new_mapping in code_mapping.items():
+        if legacy_key in parsed_data:
+            section, new_key = new_mapping
+            value = parsed_data[legacy_key]
+            if lower and isinstance(value, str):
+                value = value.lower()
+            section[new_key] = value
+    
+    if "o" in parsed_data:
+        object_id_value = parsed_data["o"]
+        if lower and isinstance(object_id_value, str):
+            object_id_value = object_id_value.lower()
+        file_map['structure']["objectid_column"] = object_id_value
+        file_map['geology']["objectid_column"] = object_id_value
+        file_map['fold']["objectid_column"] = object_id_value 
+        
+    if json_save_path is not None:
+        with open(json_save_path, "w") as f:
+            json.dump(parsed_data, f, indent=4)
+    
+    return file_map

--- a/tests/project/test_plot_hamersley.py
+++ b/tests/project/test_plot_hamersley.py
@@ -23,7 +23,6 @@ def create_project(state_data="WA", projection="EPSG:28350"):
         use_australian_state_data=state_data,
         working_projection=projection,
         bounding_box=bbox_3d,
-        clut_file_legacy=False,
         verbose_level=VerboseLevel.NONE,
         loop_project_filename=loop_project_filename,
         overwrite_loopprojectfile=True,


### PR DESCRIPTION
- Prevents the use of a config file as json or hjson. 
- Included an utils function to convert from old legacy file - `update_from_legacy_file`
- if the argument `config_filename` is used, returns ValueError. 

Usage example of converter function, using in the hjson file in [here](https://github.com/Loop3D/map2loop-notebooks/blob/master/source_data/example.hjson):

``` 
from map2loop.project import Project
from map2loop.utils import update_from_legacy_file


bounding_box = {
    "minx": 520000,  "miny": 7490000,  "maxx": 550000,  "maxy": 7510000,   "base": -3200,   "top": 1200,
}

loop_project_filename = "local_source.loop3d"

proj = Project( 
    geology_filename = r"source_data\geol_clip_no_gaps.shp", # required
    structure_filename = r"\source_data\structure_clip.shp", #required
    dtm_filename = r"source_data\dtm_rp.tif", # required
    config_dictionary = update_from_legacy_file(filename=r"source_data\example.hjson"),
    working_projection = "EPSG:28350",
    bounding_box = bounding_box,
    loop_project_filename = loop_project_filename,
    overwrite_loopprojectfile = True, 
)