### PR TITLE
fix: add debug info to thickness calculators

### DIFF
--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -85,7 +85,7 @@ class ThicknessCalculator(ABC):
             return units
 
     def _check_thickness_percentage_calculations(self, thicknesses: pandas.DataFrame):
-        units_with_no_thickness = len(thicknesses[thicknesses['ThicknessMedian'] == -1])
+        units_with_no_thickness = len(thicknesses[thicknesses['ThicknessMean'] == -1])
         total_units = len(thicknesses)
 
         if total_units > 0 and (units_with_no_thickness / total_units) >= 0.75:

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -419,7 +419,7 @@ class StructuralPoint(ThicknessCalculator):
         self.thickness_calculator_label = "StructuralPoint"
         self.strike_allowance = 30
         self.lines = None
-        super().max_line_length = max_line_length
+        super().__init__(max_line_length)
 
     @beartype.beartype
     def compute(
@@ -533,7 +533,9 @@ class StructuralPoint(ThicknessCalculator):
             )
 
             # draw orthogonal line to the strike (default value 10Km), and clip it by the bounding box of the lithology
-            B = calculate_endpoints(measurement_pt, strike, self.line_length, bbox_poly)
+            if self.max_line_length is None:
+                self.max_line_length = 10000
+            B = calculate_endpoints(measurement_pt, strike, self.max_line_length, bbox_poly)
             b = geopandas.GeoDataFrame({'geometry': [B]}).set_crs(basal_contacts.crs)
 
             # find all intersections

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -210,7 +210,7 @@ class InterpolatedStructure(ThicknessCalculator):
         Initialiser for interpolated structure version of the thickness calculator
         """
         self.thickness_calculator_label = "InterpolatedStructure"
-        self.lines = []
+        self.lines = None
         self.max_line_length = None
 
     @beartype.beartype
@@ -423,7 +423,7 @@ class StructuralPoint(ThicknessCalculator):
         self.line_length = 10000
         self.strike_allowance = 30
         self.max_line_length = None
-        self.lines = []
+        self.lines = None
 
     @beartype.beartype
     def compute(

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -394,7 +394,11 @@ class InterpolatedStructure(ThicknessCalculator):
                     f"Thickness Calculator InterpolatedStructure: Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}\n"
                 )
                 
-        self.lines = geopandas.GeoDataFrame(geometry=[line[0] for line in _lines], crs = basal_contacts.crs)
+        geometries = []
+        for line in _lines:
+            geometries.append(line)
+        
+        self.lines = geopandas.GeoDataFrame(geometry=geometries, crs = basal_contacts.crs)
         self.lines['dip'] = _dips
         self._check_thickness_percentage_calculations(thicknesses)
         return thicknesses

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -393,12 +393,8 @@ class InterpolatedStructure(ThicknessCalculator):
                 logger.warning(
                     f"Thickness Calculator InterpolatedStructure: Cannot calculate thickness between {stratigraphic_order[i]} and {stratigraphic_order[i + 1]}\n"
                 )
-                
-        geometries = []
-        for line in _lines:
-            geometries.append(line)
         
-        self.lines = geopandas.GeoDataFrame(geometry=geometries, crs = basal_contacts.crs)
+        self.lines = geopandas.GeoDataFrame(geometry=[line[0] for line in _lines], crs = basal_contacts.crs)
         self.lines['dip'] = _dips
         self._check_thickness_percentage_calculations(thicknesses)
         return thicknesses

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -210,9 +210,10 @@ class InterpolatedStructure(ThicknessCalculator):
         """
         Initialiser for interpolated structure version of the thickness calculator
         """
+        super().__init__(max_line_length)
         self.thickness_calculator_label = "InterpolatedStructure"
         self.lines = None
-        super().__init__(max_line_length)
+        
 
     @beartype.beartype
     def compute(
@@ -416,10 +417,11 @@ class StructuralPoint(ThicknessCalculator):
     '''
 
     def __init__(self, max_line_length: float = None):
+        super().__init__(max_line_length)
         self.thickness_calculator_label = "StructuralPoint"
         self.strike_allowance = 30
         self.lines = None
-        super().__init__(max_line_length)
+        
 
     @beartype.beartype
     def compute(

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -344,7 +344,7 @@ class InterpolatedStructure(ThicknessCalculator):
                     for _, row in basal_contact.iterrows():
                         # find the shortest line between the basal contact points and top contact points
                         short_line = shapely.shortest_line(row.geometry, top_contact_geometry)
-                        _lines.append(short_line)
+                        _lines.append(short_line[0])
                         
                         # check if the short line is 
                         if self.max_line_length is not None and short_line.length > self.max_line_length:
@@ -415,7 +415,7 @@ class InterpolatedStructure(ThicknessCalculator):
         self.location_tracking = combined_location_tracking
         
         # Create GeoDataFrame for lines
-        self.lines = geopandas.GeoDataFrame(geometry=[line[0] for line in _lines], crs=basal_contacts.crs)
+        self.lines = geopandas.GeoDataFrame(geometry=_lines, crs=basal_contacts.crs)
         self.lines['dip'] = _dips
         
         # Check thickness calculation

--- a/map2loop/thickness_calculator.py
+++ b/map2loop/thickness_calculator.py
@@ -33,11 +33,12 @@ class ThicknessCalculator(ABC):
         ABC (ABC): Derived from Abstract Base Class
     """
 
-    def __init__(self):
+    def __init__(self, max_line_length: float = None):
         """
         Initialiser of for ThicknessCalculator
         """
         self.thickness_calculator_label = "ThicknessCalculatorBaseClass"
+        self.max_line_length = max_line_length
 
     def type(self):
         """
@@ -205,13 +206,13 @@ class InterpolatedStructure(ThicknessCalculator):
         -> pandas.DataFrame: Calculates a thickness map for the overall map area.
     """
 
-    def __init__(self):
+    def __init__(self, max_line_length: float = None):
         """
         Initialiser for interpolated structure version of the thickness calculator
         """
         self.thickness_calculator_label = "InterpolatedStructure"
         self.lines = None
-        self.max_line_length = None
+        super().__init__(max_line_length)
 
     @beartype.beartype
     def compute(
@@ -414,12 +415,11 @@ class StructuralPoint(ThicknessCalculator):
 
     '''
 
-    def __init__(self):
+    def __init__(self, max_line_length: float = None):
         self.thickness_calculator_label = "StructuralPoint"
-        self.line_length = 10000
         self.strike_allowance = 30
-        self.max_line_length = None
         self.lines = None
+        super().max_line_length = max_line_length
 
     @beartype.beartype
     def compute(


### PR DESCRIPTION
Fixes #146 
Fixes #147. 

- Added object `lines` to each calculator -> gpd df containing linestrings + dip value(s) for each line. 
- Added warning if more than 75% of the units don't have a calculated thickness
- Added option for max_line_length

If simple review, we could add this to 3.2 too. 