### PR TITLE
chore: update conda meta.yml

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,6 +16,7 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
   run:
     - loopprojectfile ==0.2.2
     - gdal


### PR DESCRIPTION
I've observed this [conda-build](https://github.com/Loop3D/map2loop/actions/runs/12362337461/job/34502277310) error in the past, and it got fixed with adding setuptools to the host in meta.yml. 
Thought it would be worth trying. 