### PR TITLE
Fix  162

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -c conda-forge conda-build scikit-build-core numpy anaconda-client conda-libmamba-solver -y
-          conda build -c conda-forge -c loop3d --output-folder conda conda  --python ${{matrix.python-version}}
+          conda build -c conda-forge -c loop3d --output-folder conda conda  --python ${{matrix.python-version}} --solver=libmamba
           anaconda upload --label main conda/*/*.tar.bz2
 
       - name: upload artifacts

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -c conda-forge conda-build scikit-build-core numpy anaconda-client conda-libmamba-solver -y
-          conda build -c conda-forge -c loop3d --output-folder conda conda  --python ${{matrix.python-version}} --solver=libmamba
+          conda build -c conda-forge -c loop3d --output-folder conda conda  --python ${{matrix.python-version}}reve
           anaconda upload --label main conda/*/*.tar.bz2
 
       - name: upload artifacts

--- a/map2loop/config.py
+++ b/map2loop/config.py
@@ -103,9 +103,6 @@ class Config:
         # make sure dictionary doesn't contain legacy keys
         self.check_for_legacy_keys(dictionary)
         
-        # make sure it has the minimum requirements
-        self.validate_config_dictionary(dictionary)
-        
         if "structure" in dictionary:
             self.structure_config.update(dictionary["structure"])
             for key in dictionary["structure"].keys():
@@ -218,25 +215,20 @@ class Config:
 
     @beartype.beartype
     def validate_config_dictionary(self, config_dict: dict) -> None:
-        """
-        Validate the structure and keys of the configuration dictionary.
-
-        Args:
-            config_dict (dict): The config dictionary to validate.
-
-        Raises:
-            ValueError: If the dictionary does not meet the minimum requirements for ma2p2loop.
-        """    
         required_keys = {
             "structure": {"dipdir_column", "dip_column"},
             "geology": {"unitname_column", "alt_unitname_column"},
         }
 
+        # Loop over "structure" and "geology"
         for section, keys in required_keys.items():
+
+            # 1) Check that "section" exists
             if section not in config_dict:
                 logger.error(f"Missing required section '{section}' in config dictionary.")
                 raise ValueError(f"Missing required section '{section}' in config dictionary.")
-            
+
+            # 2) Check that each required key is in config_dict[section]
             for key in keys:
                 if key not in config_dict[section]:
                     logger.error(
@@ -245,6 +237,7 @@ class Config:
                     raise ValueError(
                         f"Missing required key '{key}' for '{section}' section of the config dictionary."
                     )
+
 
     @beartype.beartype
     def check_for_legacy_keys(self, config_dict: dict) -> None:

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -292,10 +292,10 @@ class Project(object):
         # Either config_filename or config_dictionary must be provided (but not both or neither)
         if not config_filename and not config_dictionary:
             logger.error(
-                "Either 'config_filename' or 'config_dictionary' must be provided to initialize the Project."
+                "A config file is required to run map2loop - use either 'config_filename' or 'config_dictionary' to initialise the project."
             )
             raise ValueError(
-                "Either 'config_filename' or 'config_dictionary' must be provided to initialize the Project."
+                 "A config file is required to run map2loop - use either 'config_filename' or 'config_dictionary' to initialise the project."
             )
         if config_filename and config_dictionary:
             logger.error(

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -142,6 +142,7 @@ class Project(object):
                 config_dictionary=config_dictionary,
                 config_filename=config_filename,
             )
+        
         self._error_state = ErrorState.NONE
         self._error_state_msg = ""
         self.verbose_level = verbose_level
@@ -230,12 +231,12 @@ class Project(object):
             self.map_data.set_config_filename(config_filename)
 
         if config_dictionary != {}:
+            self.map_data.config.validate_config_dictionary(config_dictionary)
             self.map_data.config.update_from_dictionary(config_dictionary)
             
         if clut_filename != "":
             self.map_data.set_colour_filename(clut_filename)
             
-
         
         # Load all data (both shape and raster)
         self.map_data.load_all_map_data()

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -299,10 +299,10 @@ class Project(object):
             )
         if config_filename and config_dictionary:
             logger.error(
-                "Both 'config_filename' and 'config_dictionary' were provided. Please specify only one."
+                "Both 'config_filename' and 'config_dictionary' were provided. Please specify only one config."
             )
             raise ValueError(
-                "Both 'config_filename' and 'config_dictionary' were provided. Please specify only one."
+                "Both 'config_filename' and 'config_dictionary' were provided. Please specify only one config."
             )
 
             

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -128,7 +128,7 @@ class Project(object):
                     f"Unexpected keyword argument '{key}' passed to Project. Allowed keywords: {', '.join(allowed_kwargs)}."
                 )
                 raise TypeError(
-                    f"Project got an unexpected keyword argument '{key}' - please double-check this before proceeding."
+                    f"Project got an unexpected keyword argument '{key}' - please double-check this before proceeding with map2loop processing"
                 )
         
         # make sure all the needed arguments are provided

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -269,7 +269,7 @@ class Project(object):
 
         required_inputs = {
             "bounding_box": bounding_box,
-            "working_projection": working_projection,
+            "working_projection": working_projection, # this may be removed when fix is added for https://github.com/Loop3D/map2loop/issues/103
             "geology_filename": geology_filename,
             "structure_filename": structure_filename,
             "dtm_filename": dtm_filename,

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -132,15 +132,16 @@ class Project(object):
                 )
         
         # make sure all the needed arguments are provided
-        self.validate_required_inputs(
-            bounding_box=bounding_box,
-            working_projection=working_projection,
-            geology_filename=geology_filename,
-            structure_filename=structure_filename,
-            dtm_filename=dtm_filename,
-            config_dictionary=config_dictionary,
-            config_filename=config_filename,
-        )
+        if not use_australian_state_data: # this check has to skip if using Loop server data
+            self.validate_required_inputs(
+                bounding_box=bounding_box,
+                working_projection=working_projection,
+                geology_filename=geology_filename,
+                structure_filename=structure_filename,
+                dtm_filename=dtm_filename,
+                config_dictionary=config_dictionary,
+                config_filename=config_filename,
+            )
         self._error_state = ErrorState.NONE
         self._error_state_msg = ""
         self.verbose_level = verbose_level

--- a/tests/project/test_config_arguments.py
+++ b/tests/project/test_config_arguments.py
@@ -1,0 +1,150 @@
+import pytest
+import pathlib
+from unittest.mock import patch
+from map2loop.project import Project
+from map2loop.m2l_enums import Datatype
+import map2loop
+
+# ------------------------------------------------------------------------------
+# Common fixtures or helper data (bounding box, minimal filenames, etc.)
+# ------------------------------------------------------------------------------
+
+@pytest.fixture
+def minimal_bounding_box():
+    return {
+        "minx": 515687.31005864,
+        "miny": 7493446.76593407,
+        "maxx": 562666.860106543,
+        "maxy": 7521273.57407786,
+        "base": -3200,
+        "top": 3000,
+    }
+
+@pytest.fixture
+def geology_file():
+    return str(
+        pathlib.Path(map2loop.__file__).parent
+        / pathlib.Path('_datasets/geodata_files/hamersley/geology.geojson')
+    )
+
+@pytest.fixture
+def structure_file():
+    return str(
+        pathlib.Path(map2loop.__file__).parent
+        / pathlib.Path('_datasets/geodata_files/hamersley/structure.geojson')
+    )
+
+@pytest.fixture
+def dtm_file():
+    return str(
+        pathlib.Path(map2loop.__file__).parent
+        / pathlib.Path('_datasets/geodata_files/hamersley/dtm_rp.tif')
+    )
+
+@pytest.fixture
+def valid_config_dictionary():
+    """
+    A valid config dictionary that meets the 'structure' and 'geology' requirements
+    """
+    return {
+        "structure": {
+            "dipdir_column": "azimuth2",
+            "dip_column": "dip"
+        },
+        "geology": {
+            "unitname_column": "unitname",
+            "alt_unitname_column": "code",
+        }
+    }
+
+
+
+# 1) config_filename and config_dictionary both present should raise ValueError
+def test_config_filename_and_dictionary_raises_error(
+    minimal_bounding_box, geology_file, dtm_file, structure_file, valid_config_dictionary
+):
+
+    with pytest.raises(ValueError, match="Both 'config_filename' and 'config_dictionary' were provided"):
+        Project(
+            bounding_box=minimal_bounding_box,
+            working_projection="EPSG:28350",
+            geology_filename=geology_file,
+            dtm_filename=dtm_file,
+            structure_filename=structure_file,
+            config_filename="dummy_config.json",
+            config_dictionary=valid_config_dictionary,
+        )
+        
+# 2) No config_filename or config_dictionary should raise ValueError
+def test_no_config_provided_raises_error(
+    minimal_bounding_box, geology_file, dtm_file, structure_file
+):
+
+    with pytest.raises(ValueError, match="A config file is required to run map2loop"):
+        Project(
+            bounding_box=minimal_bounding_box,
+            working_projection="EPSG:28350",
+            geology_filename=geology_file,
+            dtm_filename=dtm_file,
+            structure_filename=structure_file,
+        )
+
+# 3) Passing an unexpected argument should raise TypeError
+def test_unexpected_argument_raises_error(
+    minimal_bounding_box, geology_file, dtm_file, structure_file, valid_config_dictionary
+):
+   
+    with pytest.raises(TypeError, match="unexpected keyword argument 'config_file'"):
+        Project(
+            bounding_box=minimal_bounding_box,
+            working_projection="EPSG:28350",
+            geology_filename=geology_file,
+            dtm_filename=dtm_file,
+            structure_filename=structure_file,
+            config_dictionary=valid_config_dictionary,
+            config_file="wrong_kwarg.json", 
+        )
+
+# 4) Dictionary missing a required key should raise ValueError
+
+def test_dictionary_missing_required_key_raises_error(
+    minimal_bounding_box, geology_file, dtm_file, structure_file
+):
+
+    invalid_dictionary = {
+        "structure": {"dipdir_column": "azimuth2", "dip_column": "dip"},
+        "geology": {"unitname_column": "unitname"}  # alt_unitname_column missing
+    }
+
+    with pytest.raises(ValueError, match="Missing required key 'alt_unitname_column' for 'geology'"):
+        Project(
+            bounding_box=minimal_bounding_box,
+            working_projection="EPSG:28350",
+            geology_filename=geology_file,
+            dtm_filename=dtm_file,
+            structure_filename=structure_file,
+            config_dictionary=invalid_dictionary,
+        )
+
+# 5) All good => The Project should be created without errors
+def test_good_config_runs_successfully(
+    minimal_bounding_box, geology_file, dtm_file, structure_file, valid_config_dictionary
+):
+    project = None
+    try:
+        project = Project(
+            bounding_box=minimal_bounding_box,
+            working_projection="EPSG:28350",
+            geology_filename=geology_file,
+            dtm_filename=dtm_file,
+            structure_filename=structure_file,
+            config_dictionary=valid_config_dictionary,
+        )
+    except Exception as e:
+        pytest.fail(f"Project initialization raised an unexpected exception: {e}")
+
+    assert project is not None, "Project was not created."
+    assert project.map_data.config.structure_config["dipdir_column"] == "azimuth2"
+    assert project.map_data.config.structure_config["dip_column"] == "dip"
+    assert project.map_data.config.geology_config["unitname_column"] == "unitname"
+    assert project.map_data.config.geology_config["alt_unitname_column"] == "code"

--- a/tests/project/test_config_arguments.py
+++ b/tests/project/test_config_arguments.py
@@ -1,8 +1,6 @@
 import pytest
 import pathlib
-from unittest.mock import patch
 from map2loop.project import Project
-from map2loop.m2l_enums import Datatype
 import map2loop
 
 # ------------------------------------------------------------------------------

--- a/tests/project/test_ignore_codes_setters_getters.py
+++ b/tests/project/test_ignore_codes_setters_getters.py
@@ -2,6 +2,7 @@ import pathlib
 from map2loop.project import Project
 from map2loop.m2l_enums import Datatype
 import map2loop
+from unittest.mock import patch
 
 
 # Sample test function for lithology and fault ignore codes
@@ -21,24 +22,25 @@ def test_set_get_ignore_codes():
         "structure": {"dipdir_column": "azimuth2", "dip_column": "dip"},
         "geology": {"unitname_column": "unitname", "alt_unitname_column": "code"},
     }
-
-    project = Project(
-        working_projection='EPSG:28350',
-        bounding_box=bbox_3d,
-        geology_filename=str(
-            pathlib.Path(map2loop.__file__).parent
-            / pathlib.Path('_datasets/geodata_files/hamersley/geology.geojson')
-        ),
-        fault_filename=str(
-            pathlib.Path(map2loop.__file__).parent
-            / pathlib.Path('_datasets/geodata_files/hamersley/faults.geojson')
-        ),
-        dtm_filename=str(
-            pathlib.Path(map2loop.__file__).parent
-            / pathlib.Path('_datasets/geodata_files/hamersley/dtm_rp.tif')
-        ),
-        config_dictionary=config_dictionary,
-    )
+    with patch.object(Project, 'validate_required_inputs', return_value=None):
+        project = Project(
+            working_projection='EPSG:28350',
+            bounding_box=bbox_3d,
+            geology_filename=str(
+                pathlib.Path(map2loop.__file__).parent
+                / pathlib.Path('_datasets/geodata_files/hamersley/geology.geojson')
+            ),
+            fault_filename=str(
+                pathlib.Path(map2loop.__file__).parent
+                / pathlib.Path('_datasets/geodata_files/hamersley/faults.geojson')
+            ),
+            dtm_filename=str(
+                pathlib.Path(map2loop.__file__).parent
+                / pathlib.Path('_datasets/geodata_files/hamersley/dtm_rp.tif')
+            ),
+            config_dictionary=config_dictionary,
+            structure_filename="", 
+        )
 
     # Define test ignore codes for lithology and faults
     lithology_codes = ["cover", "Fortescue_Group", "A_FO_od"]


### PR DESCRIPTION
## Description

I noticed a while ago that Project allows unknown arguments to be passed. 

This PR intends to:
- stop the project if unknown arguments are passed 
- ensure that either config_filename or config_dictionary are present, but not none or both
- ensures that if using local data, the required datasets are provided: geology, structure, dtm, plus a bbox, and projection.                
- the projection requirement should be changed if we ever work on https://github.com/Loop3D/map2loop/issues/103

Fixes #162 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement
