### PR TITLE
chore: typo in conda build

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps"  
 
 requirements:
   host:


### PR DESCRIPTION
Removes line that shouldn't be in the conda build file, a typo that slipped from PR #170 