### PR TITLE
fix: add featureId when parsing fault_orientations

### DIFF
--- a/map2loop/mapdata.py
+++ b/map2loop/mapdata.py
@@ -763,6 +763,14 @@ class MapData:
         else:
             fault_orientations["ID"] = numpy.arange(len(fault_orientations))
         self.data[Datatype.FAULT_ORIENTATION] = fault_orientations
+        
+        if config["featureid_column"] in self.raw_data[Datatype.FAULT_ORIENTATION]:
+            fault_orientations["featureId"] = self.raw_data[Datatype.FAULT_ORIENTATION][
+                config["featureid_column"]
+            ]
+        else:
+            fault_orientations["featureId"] = numpy.arange(len(fault_orientations))
+            
         return (False, "")
 
     @beartype.beartype


### PR DESCRIPTION
## Description

Add featureId when parsing fault orientations

Fixes #(issue)

## Type of change

- [ ] Documentation update
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test improvement

## How Has This Been Tested?

Please describe any tests that you ran to verify your changes. 
Provide branch name so we can reproduce.

## Checklist:

- [X] This branch is up-to-date with master
- [ ] All gh-action checks are passing
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My tests run with pytest from the map2loop folder
- [ ] New and existing tests pass locally with my changes

## Checklist continued (if PR includes changes to documentation) 
- [ ] I have built the documentation locally with make.bat
- [ ] I have built this documentation in docker, following the docker configuration in map2loop/docs
- [ ] I have checked my spelling and grammar