### PR TITLE
fix: use pathlib.Path for save_path

### DIFF
--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -1012,7 +1012,7 @@ class Project(object):
         gdf.plot(ax=base, marker="o", color="red", markersize=5)
 
     @beartype.beartype
-    def save_mapdata_to_files(self, save_path: pathlib.Path, extension: str = ".shp.zip"):
+    def save_mapdata_to_files(self, save_path: Union[pathlib.Path,str], extension: str = ".shp.zip"):
         """
         Saves the map data frames to csv files
 
@@ -1022,8 +1022,10 @@ class Project(object):
             extension (str, optional):
                 An alternate extension to save the GeoDataFrame in. Defaults to ".csv".
         """
-        if not os.path.exists(save_path):
-            os.mkdir(save_path)
+        
+        save_path=pathlib.Path(save_path)
+        if not save_path.exists():
+            os.makedirs(save_path)
         self.map_data.save_all_map_data(save_path, extension)
 
     @beartype.beartype

--- a/map2loop/project.py
+++ b/map2loop/project.py
@@ -1012,7 +1012,7 @@ class Project(object):
         gdf.plot(ax=base, marker="o", color="red", markersize=5)
 
     @beartype.beartype
-    def save_mapdata_to_files(self, save_path: str = ".", extension: str = ".shp.zip"):
+    def save_mapdata_to_files(self, save_path: pathlib.Path, extension: str = ".shp.zip"):
         """
         Saves the map data frames to csv files
 


### PR DESCRIPTION
## Description

Fixes beartype error by adding pathlib path instead of string for  MapData.save_mapdata_to_files method

Fixes #(issue)

## Type of change

- [ ] Documentation update
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test improvement

## How Has This Been Tested?

Please describe any tests that you ran to verify your changes. 
Provide branch name so we can reproduce.

## Checklist:

- [ ] This branch is up-to-date with master
- [ ] All gh-action checks are passing
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My tests run with pytest from the map2loop folder
- [ ] New and existing tests pass locally with my changes

## Checklist continued (if PR includes changes to documentation) 
- [ ] I have built the documentation locally with make.bat
- [ ] I have built this documentation in docker, following the docker configuration in map2loop/docs
- [ ] I have checked my spelling and grammar